### PR TITLE
Add HttpResponseMessageExtensions

### DIFF
--- a/src/TestableHttpClient/HttpHeadersExtensions.cs
+++ b/src/TestableHttpClient/HttpHeadersExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Net.Http.Headers;
+
+namespace TestableHttpClient
+{
+    internal static class HttpHeadersExtensions
+    {
+        internal static bool HasHeader(this HttpHeaders headers, string headerName)
+        {
+            return headers.TryGetValues(headerName, out _);
+        }
+
+        internal static bool HasHeader(this HttpHeaders headers, string headerName, string headerValue)
+        {
+            if (headers.TryGetValues(headerName, out var values))
+            {
+                var value = string.Join(" ", values);
+                return StringMatcher.Matches(value, headerValue);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/TestableHttpClient/HttpRequestMessageExtensions.cs
+++ b/src/TestableHttpClient/HttpRequestMessageExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Text.RegularExpressions;
 
 namespace TestableHttpClient
 {
@@ -204,22 +203,6 @@ namespace TestableHttpClient
             return httpRequestMessage.Content.Headers.HasHeader(headerName, headerValue);
         }
 
-        private static bool HasHeader(this HttpHeaders headers, string headerName)
-        {
-            return headers.TryGetValues(headerName, out _);
-        }
-
-        private static bool HasHeader(this HttpHeaders headers, string headerName, string headerValue)
-        {
-            if (headers.TryGetValues(headerName, out var values))
-            {
-                var value = string.Join(" ", values);
-                return Matches(value, headerValue);
-            }
-
-            return false;
-        }
-
         /// <summary>
         /// Determines whether the request uri matches a pattern.
         /// </summary>
@@ -238,7 +221,7 @@ namespace TestableHttpClient
                 null => throw new ArgumentNullException(nameof(pattern)),
                 "" => false,
                 "*" => true,
-                _ => Matches(httpRequestMessage.RequestUri.AbsoluteUri, pattern),
+                _ => StringMatcher.Matches(httpRequestMessage.RequestUri.AbsoluteUri, pattern),
             };
         }
 
@@ -271,15 +254,8 @@ namespace TestableHttpClient
             {
                 "" => stringContent == pattern,
                 "*" => true,
-                _ => Matches(stringContent, pattern),
+                _ => StringMatcher.Matches(stringContent, pattern),
             };
-        }
-
-        private static bool Matches(string value, string pattern)
-        {
-            var regex = Regex.Escape(pattern).Replace("\\*", "(.*)");
-
-            return Regex.IsMatch(value, $"^{regex}$");
         }
     }
 }

--- a/src/TestableHttpClient/HttpResponseMessageExtensions.cs
+++ b/src/TestableHttpClient/HttpResponseMessageExtensions.cs
@@ -1,0 +1,234 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+
+namespace TestableHttpClient
+{
+    /// <summary>
+    /// A set of static methods for checking values on a <see cref="HttpResponseMessage"/>.
+    /// </summary>
+    public static class HttpResponseMessageExtensions
+    {
+        /// <summary>
+        /// Determines whether a specific HttpVersion is set on a response.
+        /// </summary>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the correct version on.</param>
+        /// <param name="httpVersion">The expected version.</param>
+        /// <returns>true when the HttpVersion matches; otherwise, false.</returns>
+        public static bool HasHttpVersion(this HttpResponseMessage httpResponseMessage, Version httpVersion)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (httpVersion == null)
+            {
+                throw new ArgumentNullException(nameof(httpVersion));
+            }
+
+            return httpResponseMessage.Version == httpVersion;
+        }
+
+        /// <summary>
+        /// Determines whether a specific HttpVersion is set on a response.
+        /// </summary>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the correct version on.</param>
+        /// <param name="httpVersion">The expected version.</param>
+        /// <returns>true when the HttpVersion matches; otherwise, false.</returns>
+        public static bool HasHttpVersion(this HttpResponseMessage httpResponseMessage, string httpVersion)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (string.IsNullOrEmpty(httpVersion))
+            {
+                throw new ArgumentNullException(nameof(httpVersion));
+            }
+
+            return HasHttpVersion(httpResponseMessage, new Version(httpVersion));
+        }
+
+        /// <summary>
+        /// Determines whether a specific status code is set on a response.
+        /// </summary>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the correct version on.</param>
+        /// <param name="httpStatusCode">The expected status code.</param>
+        /// <returns>true when the status code matches; otherwise, false.</returns>
+        public static bool HasHttpStatusCode(this HttpResponseMessage httpResponseMessage, HttpStatusCode httpStatusCode)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            return httpResponseMessage.StatusCode == httpStatusCode;
+        }
+
+        /// <summary>
+        /// Determines whether a specific reason phrase is set on a response.
+        /// </summary>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the correct version on.</param>
+        /// <param name="reasonPhrase">The expected reason phrase.</param>
+        /// <returns>true when the reason phrase matches; otherwise, false.</returns>
+        public static bool HasReasonPhrase(this HttpResponseMessage httpResponseMessage, string reasonPhrase)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (reasonPhrase == null)
+            {
+                throw new ArgumentNullException(nameof(reasonPhrase));
+            }
+
+            return httpResponseMessage.ReasonPhrase == reasonPhrase;
+        }
+
+        /// <summary>
+        /// Determines whether a specific header is set on a response.
+        /// </summary>
+        /// <remarks>This method only checks headers in <see cref="HttpRequestHeaders"/></remarks>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the response header on.</param>
+        /// <param name="headerName">The name of the header to locate on the response.</param>
+        /// <returns>true when the response contains a header with the specified name; otherwise, false.</returns>
+        public static bool HasResponseHeader(this HttpResponseMessage httpResponseMessage, string headerName)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            return httpResponseMessage.Headers.HasHeader(headerName);
+        }
+
+        /// <summary>
+        /// Determines whether a specific header with a specific value is set on a response.
+        /// </summary>
+        /// <remarks>This method only checks headers in <see cref="HttpRequestHeaders"/></remarks>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the response header on.</param>
+        /// <param name="headerName">The name of the header to locate on the response.</param>
+        /// <param name="headerValue">The value the header should have. Wildcard is supported.</param>
+        /// <returns>true when the response contains a header with the specified name and value; otherwise, false.</returns>
+        public static bool HasResponseHeader(this HttpResponseMessage httpResponseMessage, string headerName, string headerValue)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            if (string.IsNullOrEmpty(headerValue))
+            {
+                throw new ArgumentNullException(nameof(headerValue));
+            }
+
+            return httpResponseMessage.Headers.HasHeader(headerName, headerValue);
+        }
+
+        /// <summary>
+        /// Determines whether a specific header is set on a response.
+        /// </summary>
+        /// <remarks>This method only checks headers in <see cref="HttpContentHeaders"/></remarks>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the content header on.</param>
+        /// <param name="headerName">The name of the header to locate on the response content.</param>
+        /// <returns>true when the response contains a header with the specified name; otherwise, false.</returns>
+        public static bool HasContentHeader(this HttpResponseMessage httpResponseMessage, string headerName)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            if (httpResponseMessage.Content == null)
+            {
+                return false;
+            }
+
+            return httpResponseMessage.Content.Headers.HasHeader(headerName);
+        }
+
+        /// <summary>
+        /// Determines whether a specific header with a specific value is set on a response.
+        /// </summary>
+        /// <remarks>This method only checks headers in <see cref="HttpContentHeaders"/></remarks>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the content header on.</param>
+        /// <param name="headerName">The name of the header to locate on the response content.</param>
+        /// <param name="headerValue">The value the header should have. Wildcard is supported.</param>
+        /// <returns>true when the response contains a header with the specified name and value; otherwise, false.</returns>
+        public static bool HasContentHeader(this HttpResponseMessage httpResponseMessage, string headerName, string headerValue)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (string.IsNullOrEmpty(headerName))
+            {
+                throw new ArgumentNullException(nameof(headerName));
+            }
+
+            if (string.IsNullOrEmpty(headerValue))
+            {
+                throw new ArgumentNullException(nameof(headerValue));
+            }
+
+            if (httpResponseMessage.Content == null)
+            {
+                return false;
+            }
+
+            return httpResponseMessage.Content.Headers.HasHeader(headerName, headerValue);
+        }
+
+        /// <summary>
+        /// Determines whether the response content matches a string pattern.
+        /// </summary>
+        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the correct content on.</param>
+        /// <param name="pattern">A pattern to match the response content, supports * as wildcards.</param>
+        /// <returns>true when the response content matches the pattern; otherwise, false.</returns>
+        public static bool HasContent(this HttpResponseMessage httpResponseMessage, string pattern)
+        {
+            if (httpResponseMessage == null)
+            {
+                throw new ArgumentNullException(nameof(httpResponseMessage));
+            }
+
+            if (pattern == null)
+            {
+                throw new ArgumentNullException(nameof(pattern));
+            }
+
+            if (httpResponseMessage.Content == null)
+            {
+                return false;
+            }
+
+            var stringContent = httpResponseMessage.Content.ReadAsStringAsync().Result;
+
+            return pattern switch
+            {
+                "" => stringContent == pattern,
+                "*" => true,
+                _ => StringMatcher.Matches(stringContent, pattern),
+            };
+        }
+    }
+}

--- a/src/TestableHttpClient/StringMatcher.cs
+++ b/src/TestableHttpClient/StringMatcher.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.RegularExpressions;
+
+namespace TestableHttpClient
+{
+    internal static class StringMatcher
+    {
+        internal static bool Matches(string value, string pattern)
+        {
+            var regex = Regex.Escape(pattern).Replace("\\*", "(.*)");
+
+            return Regex.IsMatch(value, $"^{regex}$");
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContent.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContent.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Net.Http;
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class HttpResponseMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasContent_NullRequest_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContent(""));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasContent_NullExpectedContent_ThrowsArgumentNullException()
+        {
+            using var sut = new HttpResponseMessage();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContent(null));
+            Assert.Equal("pattern", exception.ParamName);
+        }
+#nullable enable
+
+        [Fact]
+        public void HasContent_NoContent_ReturnsFalse()
+        {
+            using var sut = new HttpResponseMessage();
+
+            Assert.False(sut.HasContent(""));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Some text")]
+        [InlineData("{\"key\":\"value\"}")]
+        public void HasContent_ExactlyMatchingStringContent_ReturnsTrue(string content)
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent(content)
+            };
+
+            Assert.True(sut.HasContent(content));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Some text")]
+        [InlineData("{\"key\":\"value\"}")]
+        public void HasContent_NotMatchingStringContent_ReturnsFalse(string content)
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("Example content")
+            };
+
+            Assert.False(sut.HasContent(content));
+        }
+
+        [Theory]
+        [InlineData("*")]
+        [InlineData("username=*&password=*")]
+        [InlineData("*admin*")]
+        public void HasContent_MatchingPattern_ReturnsTrue(string pattern)
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("username=admin&password=admin")
+            };
+
+            Assert.True(sut.HasContent(pattern));
+        }
+
+        [Theory]
+        [InlineData("admin")]
+        [InlineData("*test*")]
+        public void HasContent_NotMatchingPattern_ReturnsFalse(string pattern)
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("username=admin&password=admin")
+            };
+
+            Assert.False(sut.HasContent(pattern));
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContentHeader.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContentHeader.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class HttpResponseMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasContentHeader_NullRequest_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader("Content-Disposition"));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasContentHeader_NullHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            using var sut = new HttpResponseMessage();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader(headerName));
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasContentHeader_NullRequestNonNullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader("Content-Disposition", "inline"));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasContentHeader_NullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException(string headerName)
+        {
+            using var sut = new HttpResponseMessage();
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader(headerName, "inline"));
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasContentHeader_NonNullHeaderNameAndNullHeaderValue_ThrowsArgumentNullException(string headerValue)
+        {
+            using var sut = new HttpResponseMessage();
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasContentHeader("Content-Disposition", headerValue));
+            Assert.Equal("headerValue", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void HasContentHeader_ExistingHeaderName_ReturnsTrue()
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("")
+            };
+            sut.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("inline");
+
+            Assert.True(sut.HasContentHeader("Content-Disposition"));
+        }
+
+        [Theory]
+        [InlineData("Host")]
+        [InlineData("Content-Disposition")]
+        public void HasContentHeader_NotExistingHeaderName_ReturnsFalse(string headerName)
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("")
+            };
+
+            Assert.False(sut.HasContentHeader(headerName));
+        }
+
+        [Fact]
+        public void HasContentHeader_NoContent_ReturnsFalse()
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = null
+            };
+
+            Assert.False(sut.HasContentHeader("Content-Disposition"));
+        }
+
+        [Theory]
+        [InlineData("inline; filename=empty.file")]
+        [InlineData("inline; *")]
+        [InlineData("*; filename=empty.file")]
+        [InlineData("*")]
+        public void HasContentHeader_ExistingHeaderNameMatchingValue_ReturnsTrue(string value)
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("")
+            };
+            sut.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("inline")
+            {
+                FileName = "empty.file"
+            };
+
+            Assert.True(sut.HasContentHeader("Content-Disposition", value));
+        }
+
+        [Fact]
+        public void HasContentHeader_NotExitingHeaderNameAndValue_ReturnsFalse()
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("")
+            };
+
+            Assert.False(sut.HasContentHeader("Host", "inline"));
+        }
+
+        [Theory]
+        [InlineData("inline; filename=emtpy.file")]
+        [InlineData("inline; *")]
+        [InlineData("*; filename=empty.file")]
+        public void HasContentHeader_ExistingHeaderNameNotMatchingValue_ReturnsFalse(string value)
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("")
+            };
+            sut.Content.Headers.ContentDisposition = new ContentDispositionHeaderValue("attachment")
+            {
+                FileName = "attachment.file"
+            };
+
+            Assert.False(sut.HasContentHeader("Content-Disposition", value));
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasHttpStatusCode.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasHttpStatusCode.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class HttpResponseMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasHttpStatusCode_WithHttpStatusCode_NullHttpResponseMessage_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpStatusCode(HttpStatusCode.OK));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void HasHttpStatusCode_WithHttpStatusCode_CorrectHttpStatusCode_ReturnsTrue()
+        {
+            using var sut = new HttpResponseMessage(HttpStatusCode.OK);
+
+            Assert.True(sut.HasHttpStatusCode(HttpStatusCode.OK));
+        }
+
+        [Fact]
+        public void HasHttpStatusCode_WithHttpStatusCode_IncorrectHttpStatusCode_ReturnsFalse()
+        {
+            using var sut = new HttpResponseMessage(HttpStatusCode.BadRequest);
+
+            Assert.False(sut.HasHttpStatusCode(HttpStatusCode.OK));
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasHttpVersion.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasHttpVersion.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class HttpResponseMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasHttpVersion_WithVersion_NullResponse_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion(HttpVersion.Version20));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasHttpVersion_WithString_NullResponse_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion("1.1"));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasHttpVersion_WithVersion_NullVersion_ThrowsArgumentNullException()
+        {
+            using var sut = new HttpResponseMessage { Version = HttpVersion.Unknown };
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion((Version)null));
+            Assert.Equal("httpVersion", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasHttpVersion_WithString_NullVersion_ThrowsArgumentNullException(string httpVersion)
+        {
+            using var sut = new HttpResponseMessage { Version = HttpVersion.Unknown };
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion(httpVersion));
+            Assert.Equal("httpVersion", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void HasHttpVersion_WithVersion_CorrectVersion_ReturnsTrue()
+        {
+            using var sut = new HttpResponseMessage { Version = HttpVersion.Version11 };
+
+            Assert.True(sut.HasHttpVersion(HttpVersion.Version11));
+        }
+
+        [Fact]
+        public void HasHttpVersion_WithString_CorrectVersion_ReturnsTrue()
+        {
+            using var sut = new HttpResponseMessage { Version = HttpVersion.Version11 };
+
+            Assert.True(sut.HasHttpVersion("1.1"));
+        }
+
+        [Fact]
+        public void HasHttpVersion_WithVersion_IncorrectVersion_ReturnsFalse()
+        {
+            using var sut = new HttpResponseMessage { Version = HttpVersion.Version11 };
+
+            Assert.False(sut.HasHttpVersion(HttpVersion.Version20));
+        }
+
+        [Fact]
+        public void HasHttpVersion_WithString_IncorrectVersion_ReturnsFalse()
+        {
+            using var sut = new HttpResponseMessage { Version = HttpVersion.Version11 };
+
+            Assert.False(sut.HasHttpVersion("1.0"));
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasReasonPhrase.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasReasonPhrase.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class HttpResponseMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasReasonPhrase_WithReasonPhrase_NullResponse_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasReasonPhrase("OK"));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasReasonPhrase_WithNullReasonPhrase_ThrowsArgumentNullException()
+        {
+            using var sut = new HttpResponseMessage { ReasonPhrase = "OK" };
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasReasonPhrase(null));
+            Assert.Equal("reasonPhrase", exception.ParamName);
+        }
+#nullable restore
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("OK")]
+        public void HasReasonPhrase_WithCorrectReasonPhrase_ReturnsTrue(string reasonPhrase)
+        {
+            using var sut = new HttpResponseMessage { ReasonPhrase = reasonPhrase };
+
+            Assert.True(sut.HasReasonPhrase(reasonPhrase));
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("NotFound")]
+        public void HasReasonPhrase_WithIncorrectReasonPhrase_ReturnsTrue(string reasonPhrase)
+        {
+            using var sut = new HttpResponseMessage { ReasonPhrase = "OK" };
+
+            Assert.False(sut.HasReasonPhrase(reasonPhrase));
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasResponseHeader.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasResponseHeader.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class HttpResponseMessageExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void HasResponseHeader_NullResponse_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasResponseHeader("Server"));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasResponseHeader_NullHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            using var sut = new HttpResponseMessage();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasResponseHeader(headerName));
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Fact]
+        public void HasResponseHeader_NullResponseNonNullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException()
+        {
+            HttpResponseMessage sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasResponseHeader("Server", "value"));
+            Assert.Equal("httpResponseMessage", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasResponseHeader_NullHeaderNameAndNonNullHeaderValue_ThrowsArgumentNullException(string headerName)
+        {
+            using var sut = new HttpResponseMessage();
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasResponseHeader(headerName, "value"));
+            Assert.Equal("headerName", exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void HasResponseHeader_NonNullHeaderNameAndNullHeaderValue_ThrowsArgumentNullException(string headerValue)
+        {
+            using var sut = new HttpResponseMessage();
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasResponseHeader("Server", headerValue));
+            Assert.Equal("headerValue", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void HasRequestHeader_ExistingHeaderName_ReturnsTrue()
+        {
+            using var sut = new HttpResponseMessage();
+            sut.Headers.Add("Server", "example server");
+
+            Assert.True(sut.HasResponseHeader("Server"));
+        }
+
+        [Theory]
+        [InlineData("Host")]
+        [InlineData("Content-Type")]
+        public void HasRequestHeader_NotExistingHeaderName_ReturnsFalse(string headerName)
+        {
+            using var sut = new HttpResponseMessage();
+
+            Assert.False(sut.HasResponseHeader(headerName));
+        }
+
+        [Theory]
+        [InlineData("example server")]
+        [InlineData("example*")]
+        [InlineData("*server")]
+        [InlineData("*")]
+        public void HasResponseHeader_ExistingHeaderNameMatchingValue_ReturnsTrue(string value)
+        {
+            using var sut = new HttpResponseMessage();
+            sut.Headers.Add("Server", "example server");
+
+            Assert.True(sut.HasResponseHeader("Server", value));
+        }
+
+        [Fact]
+        public void HasResponseHeader_NotExitingHeaderNameAndValue_ReturnsFalse()
+        {
+            using var sut = new HttpResponseMessage();
+
+            Assert.False(sut.HasResponseHeader("Content-Type"));
+        }
+
+        [Theory]
+        [InlineData("example server")]
+        [InlineData("example*")]
+        [InlineData("*server")]
+        public void HasResponseHeader_ExistingHeaderNameNotMatchingValue_ReturnsFalse(string value)
+        {
+            using var sut = new HttpResponseMessage();
+            sut.Headers.Add("Server", "My Application");
+
+            Assert.False(sut.HasResponseHeader("Server", value));
+        }
+    }
+}


### PR DESCRIPTION
Extensions to simply verify information on a HttpResponseMessage.
Includes:
- HasHttpVersion
- HasHttpStatusCode
- HasReasonPhrase
- HasResponseHeader
- HasContentHeader
- HasContent