### PR TITLE
Remove deprecated API's from TestableHttpClient.

### DIFF
--- a/src/TestableHttpClient/HttpResponseMessageBuilder.cs
+++ b/src/TestableHttpClient/HttpResponseMessageBuilder.cs
@@ -24,32 +24,10 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="httpVersion">The <see cref="HttpVersion"/> of the response.</param>
         /// <returns>The <see cref="HttpResponseMessageBuilder"/> for further building of the response.</returns>
-        [Obsolete("Renamed to WithHttpVersion.", true)]
-        public HttpResponseMessageBuilder WithVersion(Version httpVersion)
-        {
-            return WithHttpVersion(httpVersion);
-        }
-
-        /// <summary>
-        /// Specifies the version of the response.
-        /// </summary>
-        /// <param name="httpVersion">The <see cref="HttpVersion"/> of the response.</param>
-        /// <returns>The <see cref="HttpResponseMessageBuilder"/> for further building of the response.</returns>
         public HttpResponseMessageBuilder WithHttpVersion(Version httpVersion)
         {
             httpResponseMessage.Version = httpVersion;
             return this;
-        }
-
-        /// <summary>
-        /// Specifies the status code of the response.
-        /// </summary>
-        /// <param name="statusCode">The <see cref="HttpStatusCode"/> of the response.</param>
-        /// <returns>The <see cref="HttpResponseMessageBuilder"/> for further building of the response.</returns>
-        [Obsolete("Renamed to WithHttpStatusCode.", true)]
-        public HttpResponseMessageBuilder WithStatusCode(HttpStatusCode httpStatusCode)
-        {
-            return WithHttpStatusCode(httpStatusCode);
         }
 
         /// <summary>
@@ -68,17 +46,6 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="responseHeaderBuilder">The builder for configuring the response headers.</param>
         /// <returns>The <see cref="HttpResponseMessageBuilder"/> for further building of the response.</returns>
-        [Obsolete("Renamed to WithResponseHeaders.", true)]
-        public HttpResponseMessageBuilder WithHeaders(Action<HttpResponseHeaders> responseHeaderBuilder)
-        {
-            return WithResponseHeaders(responseHeaderBuilder);
-        }
-
-        /// <summary>
-        /// Configure request headers using a builder by directly accessing the <see cref="HttpResponseHeaders"/>.
-        /// </summary>
-        /// <param name="responseHeaderBuilder">The builder for configuring the response headers.</param>
-        /// <returns>The <see cref="HttpResponseMessageBuilder"/> for further building of the response.</returns>
         public HttpResponseMessageBuilder WithResponseHeaders(Action<HttpResponseHeaders> responseHeaderBuilder)
         {
             if (responseHeaderBuilder == null)
@@ -88,18 +55,6 @@ namespace TestableHttpClient
 
             responseHeaderBuilder(httpResponseMessage.Headers);
             return this;
-        }
-
-        /// <summary>
-        /// Adds a request header to the response.
-        /// </summary>
-        /// <param name="header">The name of the header to add.</param>
-        /// <param name="value">The value of the header to add.</param>
-        /// <returns>The <see cref="HttpResponseMessageBuilder"/> for further building of the response.</returns>
-        [Obsolete("Renamed to WithResponseHeader.", true)]
-        public HttpResponseMessageBuilder WithHeader(string header, string value)
-        {
-            return WithResponseHeader(header, value);
         }
 
         /// <summary>

--- a/src/TestableHttpClient/HttpResponseMessageExtensions.cs
+++ b/src/TestableHttpClient/HttpResponseMessageExtensions.cs
@@ -31,28 +31,6 @@ namespace TestableHttpClient
         }
 
         /// <summary>
-        /// Determines whether a specific HttpVersion is set on a response.
-        /// </summary>
-        /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the correct version on.</param>
-        /// <param name="httpVersion">The expected version.</param>
-        /// <returns>true when the HttpVersion matches; otherwise, false.</returns>
-        [Obsolete("Use overload with System.Version instead.", true)]
-        public static bool HasHttpVersion(this HttpResponseMessage httpResponseMessage, string httpVersion)
-        {
-            if (httpResponseMessage == null)
-            {
-                throw new ArgumentNullException(nameof(httpResponseMessage));
-            }
-
-            if (string.IsNullOrEmpty(httpVersion))
-            {
-                throw new ArgumentNullException(nameof(httpVersion));
-            }
-
-            return HasHttpVersion(httpResponseMessage, new Version(httpVersion));
-        }
-
-        /// <summary>
         /// Determines whether a specific status code is set on a response.
         /// </summary>
         /// <param name="httpResponseMessage">A <see cref="HttpResponseMessage"/> to check the correct version on.</param>

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasHttpVersion.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasHttpVersion.cs
@@ -19,33 +19,11 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
-        [Obsolete("Tests obsolete message", true)]
-        public void HasHttpVersion_WithString_NullResponse_ThrowsArgumentNullException()
-        {
-            HttpResponseMessage sut = null;
-
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion("1.1"));
-            Assert.Equal("httpResponseMessage", exception.ParamName);
-        }
-
-        [Fact]
         public void HasHttpVersion_WithVersion_NullVersion_ThrowsArgumentNullException()
         {
             using var sut = new HttpResponseMessage { Version = HttpVersion.Unknown };
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion((Version)null));
-            Assert.Equal("httpVersion", exception.ParamName);
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [Obsolete("Tests obsolete message", true)]
-        public void HasHttpVersion_WithString_NullVersion_ThrowsArgumentNullException(string httpVersion)
-        {
-            using var sut = new HttpResponseMessage { Version = HttpVersion.Unknown };
-
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion(httpVersion));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.HasHttpVersion(null));
             Assert.Equal("httpVersion", exception.ParamName);
         }
 #nullable restore
@@ -59,29 +37,11 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
-        [Obsolete("Tests obsolete message", true)]
-        public void HasHttpVersion_WithString_CorrectVersion_ReturnsTrue()
-        {
-            using var sut = new HttpResponseMessage { Version = HttpVersion.Version11 };
-
-            Assert.True(sut.HasHttpVersion("1.1"));
-        }
-
-        [Fact]
         public void HasHttpVersion_WithVersion_IncorrectVersion_ReturnsFalse()
         {
             using var sut = new HttpResponseMessage { Version = HttpVersion.Version11 };
 
             Assert.False(sut.HasHttpVersion(HttpVersion.Version20));
-        }
-
-        [Fact]
-        [Obsolete("Tests obsolete message", true)]
-        public void HasHttpVersion_WithString_IncorrectVersion_ReturnsFalse()
-        {
-            using var sut = new HttpResponseMessage { Version = HttpVersion.Version11 };
-
-            Assert.False(sut.HasHttpVersion("1.0"));
         }
     }
 }


### PR DESCRIPTION
These API's were deprecated in version 0.3 and by removing these methods we get a more consistent API.

Fixes #39.