### PR TITLE
Add CreateClient methods to TestableHttpMessageHandler

### DIFF
--- a/src/TestableHttpClient/TestableHttpMessageHandlerExtensions.cs
+++ b/src/TestableHttpClient/TestableHttpMessageHandlerExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Net.Http;
+
+namespace TestableHttpClient
+{
+    public static class TestableHttpMessageHandlerExtensions
+    {
+        /// <summary>
+        /// Create an <seealso cref="HttpClient"/> configured with the TestableHttpMessageHandler.
+        /// </summary>
+        /// <param name="handler">The TestableHttpMessageHandler to set on the client.</param>
+        /// <returns>An HttpClient configure with the TestableHttpMessageHandler.</returns>
+        /// <exception cref="ArgumentNullException">The `handler` is `null`</exception>
+        /// <remarks>Using this method is equivalent to `new HttClient(handler)`.</remarks>
+        public static HttpClient CreateClient(this TestableHttpMessageHandler handler)
+        {
+            if (handler is null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            return new HttpClient(handler);
+        }
+    }
+}

--- a/src/TestableHttpClient/TestableHttpMessageHandlerExtensions.cs
+++ b/src/TestableHttpClient/TestableHttpMessageHandlerExtensions.cs
@@ -14,12 +14,32 @@ namespace TestableHttpClient
         /// <remarks>Using this method is equivalent to `new HttClient(handler)`.</remarks>
         public static HttpClient CreateClient(this TestableHttpMessageHandler handler)
         {
+            return CreateClient(handler, _ => { });
+        }
+
+        /// <summary>
+        /// Create and configure an <seealso cref="HttpClient"/> configured with the TestableHttpMessageHandler.
+        /// </summary>
+        /// <param name="handler">The TestableHttpMessageHandler to set on the client.</param>
+        /// <param name="configureClient">A delegate that is used to configure an HttpClient</param>
+        /// <returns>An HttpClient configure with the TestableHttpMessageHandler.</returns>
+        /// <exception cref="ArgumentNullException">The `handler` or `configureClient` is `null`</exception>
+        public static HttpClient CreateClient(this TestableHttpMessageHandler handler, Action<HttpClient> configureClient)
+        {
             if (handler is null)
             {
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            return new HttpClient(handler);
+            if (configureClient is null)
+            {
+                throw new ArgumentNullException(nameof(configureClient));
+            }
+
+            var httpClient = new HttpClient(handler);
+            configureClient(httpClient);
+
+            return httpClient;
         }
     }
 }

--- a/test/TestableHttpClient.IntegrationTests/CreatingClients.cs
+++ b/test/TestableHttpClient.IntegrationTests/CreatingClients.cs
@@ -1,0 +1,32 @@
+﻿using System.Net;
+using System.Threading.Tasks;
+
+using Xunit;
+
+namespace TestableHttpClient.IntegrationTests
+{
+    public class CreatingClients
+    {
+        [Fact]
+        public async Task CreateASimpleHttpClient()
+        {
+            var testableHttpMessageHandler = new TestableHttpMessageHandler();
+            var client = testableHttpMessageHandler.CreateClient();
+
+            await client.GetAsync("https://httpbin.org/get");
+
+            testableHttpMessageHandler.ShouldHaveMadeRequests().WithHttpVersion(HttpVersion.Version11);
+        }
+
+        [Fact]
+        public async Task CreateClientWithConfiguration()
+        {
+            var testableHttpMessageHandler = new TestableHttpMessageHandler();
+            var client = testableHttpMessageHandler.CreateClient(client => client.DefaultRequestVersion = HttpVersion.Version20);
+
+            await client.GetAsync("https://httpbin.org/get");
+
+            testableHttpMessageHandler.ShouldHaveMadeRequests().WithHttpVersion(HttpVersion.Version20);
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/TestableHttpClient.Tests.csproj
+++ b/test/TestableHttpClient.Tests/TestableHttpClient.Tests.csproj
@@ -10,6 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>

--- a/test/TestableHttpClient.Tests/TestableHttpMessageHandlerExtensionsTests/CreateClient.cs
+++ b/test/TestableHttpClient.Tests/TestableHttpMessageHandlerExtensionsTests/CreateClient.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Http;
 using System.Reflection;
-using System.Text;
 
 using Xunit;
 
@@ -36,7 +34,7 @@ namespace TestableHttpClient.Tests
         private static object? GetPrivateHandler(HttpClient client)
         {
             var handlerField = client.GetType().BaseType?.GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic);
-            if(handlerField == null)
+            if (handlerField == null)
             {
                 Assert.True(false, "Can't find the private _handler field on HttpClient.");
                 return null;

--- a/test/TestableHttpClient.Tests/TestableHttpMessageHandlerExtensionsTests/CreateClient.cs
+++ b/test/TestableHttpClient.Tests/TestableHttpMessageHandlerExtensionsTests/CreateClient.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class TestableHttpMessageHandlerExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void CreateClient_NullTestableHttpMessageHandler_ThrowsArgumentNullException()
+        {
+            TestableHttpMessageHandler sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.CreateClient());
+            Assert.Equal("handler", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void CreateClient_CorrectTestableHttpMessageHandler_AddsHandlerToHttpClient()
+        {
+            using var sut = new TestableHttpMessageHandler();
+
+            using var client = sut.CreateClient();
+
+            var handler = GetPrivateHandler(client);
+
+            Assert.Same(sut, handler);
+        }
+
+        private static object? GetPrivateHandler(HttpClient client)
+        {
+            var handlerField = client.GetType().BaseType?.GetField("_handler", BindingFlags.Instance | BindingFlags.NonPublic);
+            if(handlerField == null)
+            {
+                Assert.True(false, "Can't find the private _handler field on HttpClient.");
+                return null;
+            }
+            return handlerField.GetValue(client);
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/TestableHttpMessageHandlerExtensionsTests/CreateClientWithConfigurer.cs
+++ b/test/TestableHttpClient.Tests/TestableHttpMessageHandlerExtensionsTests/CreateClientWithConfigurer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Net.Http;
+
+using Moq;
+
+using Xunit;
+
+namespace TestableHttpClient.Tests
+{
+    public partial class TestableHttpMessageHandlerExtensionsTests
+    {
+#nullable disable
+        [Fact]
+        public void CreateClientWithConfigurer_NullTestableHttpMessageHandler_ThrowsArgumentNullException()
+        {
+            TestableHttpMessageHandler sut = null;
+            Action<HttpClient> configureClient = client => { };
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.CreateClient(configureClient));
+            Assert.Equal("handler", exception.ParamName);
+        }
+
+        [Fact]
+        public void CreateClientWithConfigurer_NullConfigureAction_ThrowsArgumentNullException()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            Action<HttpClient> configureClient = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.CreateClient(configureClient));
+            Assert.Equal("configureClient", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void CreateClientWithConfigurer_ReturnsHttpClientWithHandlerConfigured()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            Action<HttpClient> configureClient = client => { };
+
+            using var client = sut.CreateClient(configureClient);
+
+            var handler = GetPrivateHandler(client);
+
+            Assert.Same(sut, handler);
+        }
+
+        [Fact]
+        public void CreateClientWithConfigurer_CallsConfigureClientWithClientToReturn()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            Mock<Action<HttpClient>> configureClient = new Mock<Action<HttpClient>>();
+
+            using var client = sut.CreateClient(configureClient.Object);
+
+            configureClient.Verify(x => x.Invoke(client), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
The following methods are added:

- `TestableHttpMessageHandlerExtension.CreateClient(this TestableHttpMessageHandler)`
- `TestableHttpMessageHandlerExtension.CreateClient(this TestableHttpMessageHandler, Action<HttpClient>)`

Fixes #21.