### PR TITLE
Replace IHttpClientFactory mock with normal dependency injection.

### DIFF
--- a/test/TestableHttpClient.IntegrationTests/TestableHttpClient.IntegrationTests.csproj
+++ b/test/TestableHttpClient.IntegrationTests/TestableHttpClient.IntegrationTests.csproj
@@ -9,13 +9,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
-    <PackageReference Include="Moq" Version="4.14.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This way the code look closer how it is used in real world scenario's. For unittests the serviceProvider is easily created and configured, for integration tests the TestServer works the same way.

Related #36 