### PR TITLE
Add expectedNumberOfRequests parameter to With methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Deprecated
+- `WithUriPattern(this IHttpRequestMessagesCheck, string)` will be removed in favour of `WithRequestUri(this IHttpRequestMessagesCheck, string)`
+- `With(Func<HttpRequestMessage, bool>, string)` will be removed in favour of `WithFilter(Func<HttpRequestMessage, bool>, string)`, since it conflicts with the language keyword `with`.
+- `Times(int)` will be removed in favour of the `With*` methods with an `int` parameter.
+
 ### Added
 - It is now possible to use NFluent to check `TestableHttpMessageHandler` by using `Check.That(handler).HasMadeRequests()` and `Check.That(handler).HasMadeRequestsTo("https://github.com/dnperfors/testablehttpclient")`. All existing `With` checks are supported.
-- All `With*` methods got an extra overload to specify the expected number of requests. This is instead of the `Times` method.
+- All `With*` methods got an extra overload to specify the exact number of expected requests. This is instead of the `Times` method.
+
 ### Changed
 - Introduced `IHttpRequestMessagesCheck` as the public interface for all checks on requests made to `TestableHttpMessageHandler`. It contains the following api:
   - `WithFilter(Func<HttpRequestMessage, bool>, string)`
+  - `WithFilter(Func<HttpRequestMessage, bool>, int, string)`
+  - `WithFilter(Func<HttpRequestMessage, bool>, int?, string)`
 - Moved some api's from `TestableHttpMessageHandler` to `TestableHttpMessageHandlerAssertionExtensions`:
   - `ShouldHaveMadeRequests(this TestableHttpMessageHandler)`
   - `ShouldHaveMadeRequestsTo(this TestableHttpMessageHandler, string)`
@@ -29,11 +37,6 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - `WithContent(this IHttpRequestMessagesCheck, string)`
   - `WithJsonContent(this IHttpRequestMessagesCheck, object)`
   - `WithFormUrlEncodedContent(this IHttpRequestMessagesCheck, IEnumerable<KeyValuePair<string, string>)`
-
-### Deprecated
-- `WithUriPattern(this IHttpRequestMessagesCheck, string)` will be removed in favour of `WithRequestUri(this IHttpRequestMessagesCheck, string)`
-- `With(Func<HttpRequestMessage, bool>, string)` will be removed in favour of `WithFilter(Func<HttpRequestMessage, bool>, string)`, since it conflicts with the language keyword `with`.
-- `Times(int)` will be removed in favour of the `With*` methods with an `int` parameter.
 
 ### Removed
 - `HttpRequestMessageAsserter` is made internal.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased]
 ### Added
 - It is now possible to use NFluent to check `TestableHttpMessageHandler` by using `Check.That(handler).HasMadeRequests()` and `Check.That(handler).HasMadeRequestsTo("https://github.com/dnperfors/testablehttpclient")`. All existing `With` checks are supported.
+- All `With*` methods got an extra overload to specify the expected number of requests. This is instead of the `Times` method.
 ### Changed
 - Introduced `IHttpRequestMessagesCheck` as the public interface for all checks on requests made to `TestableHttpMessageHandler`. It contains the following api:
-  - `With(Func<HttpRequestMessage, bool>, string)`
-  - `Times(int)`
+  - `WithFilter(Func<HttpRequestMessage, bool>, string)`
 - Moved some api's from `TestableHttpMessageHandler` to `TestableHttpMessageHandlerAssertionExtensions`:
   - `ShouldHaveMadeRequests(this TestableHttpMessageHandler)`
   - `ShouldHaveMadeRequestsTo(this TestableHttpMessageHandler, string)`
@@ -32,6 +32,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Deprecated
 - `WithUriPattern(this IHttpRequestMessagesCheck, string)` will be removed in favour of `WithRequestUri(this IHttpRequestMessagesCheck, string)`
+- `With(Func<HttpRequestMessage, bool>, string)` will be removed in favour of `WithFilter(Func<HttpRequestMessage, bool>, string)`, since it conflicts with the language keyword `with`.
+- `Times(int)` will be removed in favour of the `With*` methods with an `int` parameter.
 
 ### Removed
 - `HttpRequestMessageAsserter` is made internal.

--- a/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
+++ b/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
@@ -22,14 +22,14 @@ namespace TestableHttpClient.NFluent
         public FluentHttpRequestMessagesChecks(IEnumerable<HttpRequestMessage> httpRequestMessages)
             : base(httpRequestMessages, Check.Reporter, false)
         {
-            if (httpRequestMessages == null)
-            {
-                throw new ArgumentNullException(nameof(httpRequestMessages));
-            }
-            requests = httpRequestMessages;
+            requests = httpRequestMessages ?? throw new ArgumentNullException(nameof(httpRequestMessages));
         }
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, string message)
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, string message) => With(predicate, null, message);
+
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, int expectedNumberOfRequests, string message) => With(predicate, (int?)expectedNumberOfRequests, message);
+
+        private IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, int? expectedNumberOfRequests, string message)
         {
             if (!string.IsNullOrEmpty(message))
             {
@@ -41,10 +41,11 @@ namespace TestableHttpClient.NFluent
                 .FailWhen(_ => predicate == null, "The predicate should not be null.", MessageOption.NoCheckedBlock | MessageOption.NoExpectedBlock)
                 .Analyze((sut, _) => requests = requests.Where(predicate));
 
-            AnalyzeNumberOfRequests(checkLogic, null);
+            AnalyzeNumberOfRequests(checkLogic, expectedNumberOfRequests);
             return this;
         }
 
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public IHttpRequestMessagesCheck Times(int count)
         {
             var checkLogic = ExtensibilityHelper.BeginCheck(this)

--- a/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
+++ b/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
@@ -25,6 +25,9 @@ namespace TestableHttpClient.NFluent
             requests = httpRequestMessages ?? throw new ArgumentNullException(nameof(httpRequestMessages));
         }
 
+        [Obsolete("With is a language keyword and should be avoided, use WithFilter instead.", true)]
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, condition);
+
         public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, null, condition);
 
         public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => WithFilter(requestFilter, (int?)expectedNumberOfRequests, condition);

--- a/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
+++ b/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
@@ -26,7 +26,7 @@ namespace TestableHttpClient.NFluent
         }
 
         [Obsolete("With is a language keyword and should be avoided, use WithFilter instead.", true)]
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, condition);
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, string message) => WithFilter(predicate, message);
 
         public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, null, condition);
 

--- a/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
+++ b/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
@@ -25,11 +25,11 @@ namespace TestableHttpClient.NFluent
             requests = httpRequestMessages ?? throw new ArgumentNullException(nameof(httpRequestMessages));
         }
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => With(requestFilter, null, condition);
+        public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, null, condition);
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => With(requestFilter, (int?)expectedNumberOfRequests, condition);
+        public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => WithFilter(requestFilter, (int?)expectedNumberOfRequests, condition);
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
+        public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
         {
             if (!string.IsNullOrEmpty(condition))
             {
@@ -37,7 +37,7 @@ namespace TestableHttpClient.NFluent
             }
 
             var checkLogic = ExtensibilityHelper.BeginCheck(this)
-                .CantBeNegated(nameof(With))
+                .CantBeNegated(nameof(WithFilter))
                 .FailWhen(_ => requestFilter == null, "The request filter should not be null.", MessageOption.NoCheckedBlock | MessageOption.NoExpectedBlock)
                 .Analyze((sut, _) => requests = requests.Where(requestFilter));
 

--- a/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
+++ b/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
@@ -25,21 +25,21 @@ namespace TestableHttpClient.NFluent
             requests = httpRequestMessages ?? throw new ArgumentNullException(nameof(httpRequestMessages));
         }
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, string message) => With(predicate, null, message);
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => With(requestFilter, null, condition);
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, int expectedNumberOfRequests, string message) => With(predicate, (int?)expectedNumberOfRequests, message);
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => With(requestFilter, (int?)expectedNumberOfRequests, condition);
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, int? expectedNumberOfRequests, string message)
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
         {
-            if (!string.IsNullOrEmpty(message))
+            if (!string.IsNullOrEmpty(condition))
             {
-                requestConditions.Add(message);
+                requestConditions.Add(condition);
             }
 
             var checkLogic = ExtensibilityHelper.BeginCheck(this)
                 .CantBeNegated(nameof(With))
-                .FailWhen(_ => predicate == null, "The predicate should not be null.", MessageOption.NoCheckedBlock | MessageOption.NoExpectedBlock)
-                .Analyze((sut, _) => requests = requests.Where(predicate));
+                .FailWhen(_ => requestFilter == null, "The request filter should not be null.", MessageOption.NoCheckedBlock | MessageOption.NoExpectedBlock)
+                .Analyze((sut, _) => requests = requests.Where(requestFilter));
 
             AnalyzeNumberOfRequests(checkLogic, expectedNumberOfRequests);
             return this;

--- a/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
+++ b/src/TestableHttpClient.NFluent/FluentHttpRequestMessagesChecks.cs
@@ -29,7 +29,7 @@ namespace TestableHttpClient.NFluent
 
         public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, int expectedNumberOfRequests, string message) => With(predicate, (int?)expectedNumberOfRequests, message);
 
-        private IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, int? expectedNumberOfRequests, string message)
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, int? expectedNumberOfRequests, string message)
         {
             if (!string.IsNullOrEmpty(message))
             {

--- a/src/TestableHttpClient/HttpRequestMessageAsserter.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAsserter.cs
@@ -71,7 +71,17 @@ namespace TestableHttpClient
         /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
         /// <param name="condition">The name of the conditon, used in the exception message.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition)
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => With(requestFilter, null, condition);
+
+        /// <summary>
+        /// Asserts whether requests comply with a specific filter.
+        /// </summary>
+        /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
+        /// <param name="condition">The name of the conditon, used in the exception message.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => With(requestFilter, (int?)expectedNumberOfRequests, condition);
+
+        private IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
         {
             if (!string.IsNullOrEmpty(condition))
             {
@@ -79,7 +89,7 @@ namespace TestableHttpClient
             }
 
             Requests = Requests.Where(requestFilter);
-            Assert();
+            Assert(expectedNumberOfRequests);
             return this;
         }
 
@@ -88,6 +98,7 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="count">The number of requests that are expected, should be a positive value.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public IHttpRequestMessagesCheck Times(int count)
         {
             if (count < 0)

--- a/src/TestableHttpClient/HttpRequestMessageAsserter.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAsserter.cs
@@ -65,8 +65,14 @@ namespace TestableHttpClient
             }
         }
 
+        /// <summary>
+        /// Asserts whether requests comply with a specific filter.
+        /// </summary>
+        /// <param name="predicate">The filter to filter requests with before asserting.</param>
+        /// <param name="message">The name of the conditon, used in the exception message.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         [Obsolete("With is a language keyword and should be avoided, use WithFilter instead.", true)]
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, condition);
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> predicate, string message) => WithFilter(predicate, message);
 
         /// <summary>
         /// Asserts whether requests comply with a specific filter.

--- a/src/TestableHttpClient/HttpRequestMessageAsserter.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAsserter.cs
@@ -65,6 +65,9 @@ namespace TestableHttpClient
             }
         }
 
+        [Obsolete("With is a language keyword and should be avoided, use WithFilter instead.", true)]
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, condition);
+
         /// <summary>
         /// Asserts whether requests comply with a specific filter.
         /// </summary>
@@ -98,7 +101,7 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="count">The number of requests that are expected, should be a positive value.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
+        [Obsolete("Times as a seperate check is no longer supported, use the WithFilter overload with expectdNumberOfRequests.", true)]
         public IHttpRequestMessagesCheck Times(int count)
         {
             if (count < 0)

--- a/src/TestableHttpClient/HttpRequestMessageAsserter.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAsserter.cs
@@ -71,7 +71,7 @@ namespace TestableHttpClient
         /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
         /// <param name="condition">The name of the conditon, used in the exception message.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition) => With(requestFilter, null, condition);
+        public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, string condition) => WithFilter(requestFilter, null, condition);
 
         /// <summary>
         /// Asserts whether requests comply with a specific filter.
@@ -79,9 +79,9 @@ namespace TestableHttpClient
         /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
         /// <param name="condition">The name of the conditon, used in the exception message.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => With(requestFilter, (int?)expectedNumberOfRequests, condition);
+        public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => WithFilter(requestFilter, (int?)expectedNumberOfRequests, condition);
 
-        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
+        public IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
         {
             if (!string.IsNullOrEmpty(condition))
             {

--- a/src/TestableHttpClient/HttpRequestMessageAsserter.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAsserter.cs
@@ -81,7 +81,7 @@ namespace TestableHttpClient
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition) => With(requestFilter, (int?)expectedNumberOfRequests, condition);
 
-        private IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
+        public IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition)
         {
             if (!string.IsNullOrEmpty(condition))
             {

--- a/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
+++ b/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
@@ -54,7 +54,7 @@ namespace TestableHttpClient
                 condition = $"uri pattern '{pattern}'";
             }
 
-            return check.With(x => x.HasMatchingUri(pattern), numberOfRequests, condition);
+            return check.WithFilter(x => x.HasMatchingUri(pattern), numberOfRequests, condition);
         }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(httpMethod));
             }
 
-            return check.With(x => x.HasHttpMethod(httpMethod), numberOfRequests, $"HTTP Method '{httpMethod}'");
+            return check.WithFilter(x => x.HasHttpMethod(httpMethod), numberOfRequests, $"HTTP Method '{httpMethod}'");
         }
 
         /// <summary>
@@ -118,7 +118,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(httpVersion));
             }
 
-            return check.With(x => x.HasHttpVersion(httpVersion), numberOfRequests, $"HTTP Version '{httpVersion}'");
+            return check.WithFilter(x => x.HasHttpVersion(httpVersion), numberOfRequests, $"HTTP Version '{httpVersion}'");
         }
 
         /// <summary>
@@ -152,7 +152,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName), numberOfRequests, $"request header '{headerName}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName), numberOfRequests, $"request header '{headerName}'");
         }
 
         /// <summary>
@@ -193,7 +193,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName, headerValue), numberOfRequests, $"request header '{headerName}' and value '{headerValue}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName, headerValue), numberOfRequests, $"request header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.With(x => x.HasContentHeader(headerName), numberOfRequests, $"content header '{headerName}'");
+            return check.WithFilter(x => x.HasContentHeader(headerName), numberOfRequests, $"content header '{headerName}'");
         }
 
         /// <summary>
@@ -268,7 +268,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.With(x => x.HasContentHeader(headerName, headerValue), numberOfRequests, $"content header '{headerName}' and value '{headerValue}'");
+            return check.WithFilter(x => x.HasContentHeader(headerName, headerValue), numberOfRequests, $"content header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -300,7 +300,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName) || x.HasContentHeader(headerName), numberOfRequests, $"header '{headerName}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName) || x.HasContentHeader(headerName), numberOfRequests, $"header '{headerName}'");
         }
 
         /// <summary>
@@ -339,7 +339,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName, headerValue) || x.HasContentHeader(headerName, headerValue), numberOfRequests, $"header '{headerName}' and value '{headerValue}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName, headerValue) || x.HasContentHeader(headerName, headerValue), numberOfRequests, $"header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -371,7 +371,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            return check.With(x => x.HasContent(pattern), numberOfRequests, $"content '{pattern}'");
+            return check.WithFilter(x => x.HasContent(pattern), numberOfRequests, $"content '{pattern}'");
         }
 
         /// <summary>
@@ -399,7 +399,7 @@ namespace TestableHttpClient
             }
 
             var jsonString = JsonSerializer.Serialize(jsonObject);
-            return check.With(x => x.HasContent(jsonString) && x.HasContentHeader("Content-Type", "application/json*"), numberOfRequests, $"json content '{jsonString}'");
+            return check.WithFilter(x => x.HasContent(jsonString) && x.HasContentHeader("Content-Type", "application/json*"), numberOfRequests, $"json content '{jsonString}'");
         }
 
         /// <summary>
@@ -434,7 +434,7 @@ namespace TestableHttpClient
             using var content = new FormUrlEncodedContent(nameValueCollection);
             var contentString = content.ReadAsStringAsync().Result;
 
-            return check.With(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), numberOfRequests, $"form url encoded content '{contentString}'");
+            return check.WithFilter(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), numberOfRequests, $"form url encoded content '{contentString}'");
         }
     }
 }

--- a/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
+++ b/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
@@ -25,7 +25,11 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="pattern">The uri pattern that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern)
+        public static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern) => WithRequestUri(check, pattern, null);
+
+        public static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int numberOfRequests) => WithRequestUri(check, pattern, (int?)numberOfRequests);
+
+        private static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -43,7 +47,7 @@ namespace TestableHttpClient
                 condition = $"uri pattern '{pattern}'";
             }
 
-            return check.With(x => x.HasMatchingUri(pattern), condition);
+            return check.With(x => x.HasMatchingUri(pattern), numberOfRequests, condition);
         }
 
         /// <summary>
@@ -52,7 +56,11 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="httpMethod">The <seealso cref="HttpMethod"/> that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod)
+        public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod) => WithHttpMethod(check, httpMethod, null);
+
+        public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int numberOfRequests) => WithHttpMethod(check, httpMethod, (int?)numberOfRequests);
+
+        public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -64,7 +72,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(httpMethod));
             }
 
-            return check.With(x => x.HasHttpMethod(httpMethod), $"HTTP Method '{httpMethod}'");
+            return check.With(x => x.HasHttpMethod(httpMethod), numberOfRequests, $"HTTP Method '{httpMethod}'");
         }
 
         /// <summary>
@@ -73,7 +81,9 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="httpVersion">The <seealso cref="System.Net.HttpVersion"/> that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion)
+        public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion) => WithHttpVersion(check, httpVersion, null);
+        public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int numberOfRequests) => WithHttpVersion(check, httpVersion, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -85,7 +95,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(httpVersion));
             }
 
-            return check.With(x => x.HasHttpVersion(httpVersion), $"HTTP Version '{httpVersion}'");
+            return check.With(x => x.HasHttpVersion(httpVersion), numberOfRequests, $"HTTP Version '{httpVersion}'");
         }
 
         /// <summary>
@@ -95,7 +105,9 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName)
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName) => WithRequestHeader(check, headerName, (int?)null);
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithRequestHeader(check, headerName, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -107,7 +119,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName), $"request header '{headerName}'");
+            return check.With(x => x.HasRequestHeader(headerName), numberOfRequests, $"request header '{headerName}'");
         }
 
         /// <summary>
@@ -118,7 +130,9 @@ namespace TestableHttpClient
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue)
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue) => WithRequestHeader(check, headerName, headerValue, null);
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithRequestHeader(check, headerName, headerValue, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -135,7 +149,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName, headerValue), $"request header '{headerName}' and value '{headerValue}'");
+            return check.With(x => x.HasRequestHeader(headerName, headerValue), numberOfRequests, $"request header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -145,7 +159,9 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName)
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName) => WithContentHeader(check, headerName, (int?)null);
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithContentHeader(check, headerName, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -157,7 +173,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.With(x => x.HasContentHeader(headerName), $"content header '{headerName}'");
+            return check.With(x => x.HasContentHeader(headerName), numberOfRequests, $"content header '{headerName}'");
         }
 
         /// <summary>
@@ -168,7 +184,9 @@ namespace TestableHttpClient
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue)
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue) => WithContentHeader(check, headerName, headerValue, (int?)null);
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithContentHeader(check, headerName, headerValue, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -185,7 +203,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.With(x => x.HasContentHeader(headerName, headerValue), $"content header '{headerName}' and value '{headerValue}'");
+            return check.With(x => x.HasContentHeader(headerName, headerValue), numberOfRequests, $"content header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -194,7 +212,9 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName)
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName) => WithHeader(check, headerName, (int?)null);
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithHeader(check, headerName, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -206,7 +226,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName) || x.HasContentHeader(headerName), $"header '{headerName}'");
+            return check.With(x => x.HasRequestHeader(headerName) || x.HasContentHeader(headerName), numberOfRequests, $"header '{headerName}'");
         }
 
         /// <summary>
@@ -216,7 +236,9 @@ namespace TestableHttpClient
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue)
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue) => WithHeader(check, headerName, headerValue, (int?)null);
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithHeader(check, headerName, headerValue, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -233,7 +255,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.With(x => x.HasRequestHeader(headerName, headerValue) || x.HasContentHeader(headerName, headerValue), $"header '{headerName}' and value '{headerValue}'");
+            return check.With(x => x.HasRequestHeader(headerName, headerValue) || x.HasContentHeader(headerName, headerValue), numberOfRequests, $"header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -242,7 +264,9 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="pattern">The expected content, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern)
+        public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern) => WithContent(check, pattern, null);
+        public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int numberOfRequests) => WithContent(check, pattern, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -254,7 +278,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            return check.With(x => x.HasContent(pattern), $"content '{pattern}'");
+            return check.With(x => x.HasContent(pattern), numberOfRequests, $"content '{pattern}'");
         }
 
         /// <summary>
@@ -263,7 +287,9 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="jsonObject">The object representation of the expected request content.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject)
+        public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject) => WithJsonContent(check, jsonObject, null);
+        public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int numberOfRequests) => WithJsonContent(check, jsonObject, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -271,7 +297,7 @@ namespace TestableHttpClient
             }
 
             var jsonString = JsonSerializer.Serialize(jsonObject);
-            return check.With(x => x.HasContent(jsonString) && x.HasContentHeader("Content-Type", "application/json*"), $"json content '{jsonString}'");
+            return check.With(x => x.HasContent(jsonString) && x.HasContentHeader("Content-Type", "application/json*"), numberOfRequests, $"json content '{jsonString}'");
         }
 
         /// <summary>
@@ -280,7 +306,9 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="nameValueCollection">The collection of key/value pairs that should be url encoded.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection)
+        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection) => WithFormUrlEncodedContent(check, nameValueCollection, null);
+        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int numberOfRequests) => WithFormUrlEncodedContent(check, nameValueCollection, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -295,7 +323,7 @@ namespace TestableHttpClient
             using var content = new FormUrlEncodedContent(nameValueCollection);
             var contentString = content.ReadAsStringAsync().Result;
 
-            return check.With(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), $"form url encoded content '{contentString}'");
+            return check.With(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), numberOfRequests,$"form url encoded content '{contentString}'");
         }
     }
 }

--- a/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
+++ b/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
@@ -32,11 +32,11 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="pattern">The uri pattern that is expected.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int numberOfRequests) => WithRequestUri(check, pattern, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int expectedNumberOfRequests) => WithRequestUri(check, pattern, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -54,7 +54,7 @@ namespace TestableHttpClient
                 condition = $"uri pattern '{pattern}'";
             }
 
-            return check.WithFilter(x => x.HasMatchingUri(pattern), numberOfRequests, condition);
+            return check.WithFilter(x => x.HasMatchingUri(pattern), expectedNumberOfRequests, condition);
         }
 
         /// <summary>
@@ -70,11 +70,11 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="httpMethod">The <seealso cref="HttpMethod"/> that is expected.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int numberOfRequests) => WithHttpMethod(check, httpMethod, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int expectedNumberOfRequests) => WithHttpMethod(check, httpMethod, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -86,7 +86,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(httpMethod));
             }
 
-            return check.WithFilter(x => x.HasHttpMethod(httpMethod), numberOfRequests, $"HTTP Method '{httpMethod}'");
+            return check.WithFilter(x => x.HasHttpMethod(httpMethod), expectedNumberOfRequests, $"HTTP Method '{httpMethod}'");
         }
 
         /// <summary>
@@ -102,11 +102,11 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="httpVersion">The <seealso cref="System.Net.HttpVersion"/> that is expected.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int numberOfRequests) => WithHttpVersion(check, httpVersion, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int expectedNumberOfRequests) => WithHttpVersion(check, httpVersion, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -118,7 +118,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(httpVersion));
             }
 
-            return check.WithFilter(x => x.HasHttpVersion(httpVersion), numberOfRequests, $"HTTP Version '{httpVersion}'");
+            return check.WithFilter(x => x.HasHttpVersion(httpVersion), expectedNumberOfRequests, $"HTTP Version '{httpVersion}'");
         }
 
         /// <summary>
@@ -136,11 +136,11 @@ namespace TestableHttpClient
         /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpRequestHeader"/></remarks>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithRequestHeader(check, headerName, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int expectedNumberOfRequests) => WithRequestHeader(check, headerName, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -152,7 +152,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.WithFilter(x => x.HasRequestHeader(headerName), numberOfRequests, $"request header '{headerName}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName), expectedNumberOfRequests, $"request header '{headerName}'");
         }
 
         /// <summary>
@@ -172,11 +172,11 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithRequestHeader(check, headerName, headerValue, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int expectedNumberOfRequests) => WithRequestHeader(check, headerName, headerValue, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -193,7 +193,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.WithFilter(x => x.HasRequestHeader(headerName, headerValue), numberOfRequests, $"request header '{headerName}' and value '{headerValue}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName, headerValue), expectedNumberOfRequests, $"request header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -211,11 +211,11 @@ namespace TestableHttpClient
         /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpContentHeader"/></remarks>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithContentHeader(check, headerName, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int expectedNumberOfRequests) => WithContentHeader(check, headerName, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -227,7 +227,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.WithFilter(x => x.HasContentHeader(headerName), numberOfRequests, $"content header '{headerName}'");
+            return check.WithFilter(x => x.HasContentHeader(headerName), expectedNumberOfRequests, $"content header '{headerName}'");
         }
 
         /// <summary>
@@ -247,11 +247,11 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithContentHeader(check, headerName, headerValue, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int expectedNumberOfRequests) => WithContentHeader(check, headerName, headerValue, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -268,7 +268,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.WithFilter(x => x.HasContentHeader(headerName, headerValue), numberOfRequests, $"content header '{headerName}' and value '{headerValue}'");
+            return check.WithFilter(x => x.HasContentHeader(headerName, headerValue), expectedNumberOfRequests, $"content header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -284,11 +284,11 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithHeader(check, headerName, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int expectedNumberOfRequests) => WithHeader(check, headerName, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -300,7 +300,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerName));
             }
 
-            return check.WithFilter(x => x.HasRequestHeader(headerName) || x.HasContentHeader(headerName), numberOfRequests, $"header '{headerName}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName) || x.HasContentHeader(headerName), expectedNumberOfRequests, $"header '{headerName}'");
         }
 
         /// <summary>
@@ -318,11 +318,11 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithHeader(check, headerName, headerValue, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int expectedNumberOfRequests) => WithHeader(check, headerName, headerValue, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -339,7 +339,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(headerValue));
             }
 
-            return check.WithFilter(x => x.HasRequestHeader(headerName, headerValue) || x.HasContentHeader(headerName, headerValue), numberOfRequests, $"header '{headerName}' and value '{headerValue}'");
+            return check.WithFilter(x => x.HasRequestHeader(headerName, headerValue) || x.HasContentHeader(headerName, headerValue), expectedNumberOfRequests, $"header '{headerName}' and value '{headerValue}'");
         }
 
         /// <summary>
@@ -355,11 +355,11 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="pattern">The expected content, supports wildcards.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int numberOfRequests) => WithContent(check, pattern, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int expectedNumberOfRequests) => WithContent(check, pattern, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -371,7 +371,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            return check.WithFilter(x => x.HasContent(pattern), numberOfRequests, $"content '{pattern}'");
+            return check.WithFilter(x => x.HasContent(pattern), expectedNumberOfRequests, $"content '{pattern}'");
         }
 
         /// <summary>
@@ -387,11 +387,11 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="jsonObject">The object representation of the expected request content.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int numberOfRequests) => WithJsonContent(check, jsonObject, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int expectedNumberOfRequests) => WithJsonContent(check, jsonObject, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -399,7 +399,7 @@ namespace TestableHttpClient
             }
 
             var jsonString = JsonSerializer.Serialize(jsonObject);
-            return check.WithFilter(x => x.HasContent(jsonString) && x.HasContentHeader("Content-Type", "application/json*"), numberOfRequests, $"json content '{jsonString}'");
+            return check.WithFilter(x => x.HasContent(jsonString) && x.HasContentHeader("Content-Type", "application/json*"), expectedNumberOfRequests, $"json content '{jsonString}'");
         }
 
         /// <summary>
@@ -415,11 +415,11 @@ namespace TestableHttpClient
         /// </summary>
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="nameValueCollection">The collection of key/value pairs that should be url encoded.</param>
-        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int numberOfRequests) => WithFormUrlEncodedContent(check, nameValueCollection, (int?)numberOfRequests);
+        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int expectedNumberOfRequests) => WithFormUrlEncodedContent(check, nameValueCollection, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int? expectedNumberOfRequests)
         {
             if (check == null)
             {
@@ -434,7 +434,7 @@ namespace TestableHttpClient
             using var content = new FormUrlEncodedContent(nameValueCollection);
             var contentString = content.ReadAsStringAsync().Result;
 
-            return check.WithFilter(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), numberOfRequests, $"form url encoded content '{contentString}'");
+            return check.WithFilter(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), expectedNumberOfRequests, $"form url encoded content '{contentString}'");
         }
     }
 }

--- a/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
+++ b/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
@@ -27,6 +27,13 @@ namespace TestableHttpClient
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern) => WithRequestUri(check, pattern, null);
 
+        /// <summary>
+        /// Asserts whether requests were made to a given URI based on a pattern.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="pattern">The uri pattern that is expected.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int numberOfRequests) => WithRequestUri(check, pattern, (int?)numberOfRequests);
 
         private static IHttpRequestMessagesCheck WithRequestUri(this IHttpRequestMessagesCheck check, string pattern, int? numberOfRequests)
@@ -58,9 +65,16 @@ namespace TestableHttpClient
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod) => WithHttpMethod(check, httpMethod, null);
 
+        /// <summary>
+        /// Asserts whether requests were made with a given HTTP Method.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="httpMethod">The <seealso cref="HttpMethod"/> that is expected.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int numberOfRequests) => WithHttpMethod(check, httpMethod, (int?)numberOfRequests);
 
-        public static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int? numberOfRequests)
+        private static IHttpRequestMessagesCheck WithHttpMethod(this IHttpRequestMessagesCheck check, HttpMethod httpMethod, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -82,8 +96,17 @@ namespace TestableHttpClient
         /// <param name="httpVersion">The <seealso cref="System.Net.HttpVersion"/> that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion) => WithHttpVersion(check, httpVersion, null);
+
+        /// <summary>
+        /// Asserts whether requests were made using a specific HTTP Version.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="httpVersion">The <seealso cref="System.Net.HttpVersion"/> that is expected.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int numberOfRequests) => WithHttpVersion(check, httpVersion, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithHttpVersion(this IHttpRequestMessagesCheck check, Version httpVersion, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -106,8 +129,18 @@ namespace TestableHttpClient
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName) => WithRequestHeader(check, headerName, (int?)null);
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name. Values are ignored.
+        /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpRequestHeader"/></remarks>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithRequestHeader(check, headerName, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -131,8 +164,19 @@ namespace TestableHttpClient
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue) => WithRequestHeader(check, headerName, headerValue, null);
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name and value.
+        /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpRequestHeader"/></remarks>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithRequestHeader(check, headerName, headerValue, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithRequestHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -160,8 +204,18 @@ namespace TestableHttpClient
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName) => WithContentHeader(check, headerName, (int?)null);
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name. Values are ignored.
+        /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpContentHeader"/></remarks>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithContentHeader(check, headerName, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -185,8 +239,19 @@ namespace TestableHttpClient
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue) => WithContentHeader(check, headerName, headerValue, (int?)null);
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name and value.
+        /// </summary>
+        /// <remarks>This method only asserts headers on <see cref="System.Net.Http.Headers.HttpContentHeader"/></remarks>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithContentHeader(check, headerName, headerValue, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithContentHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -213,8 +278,17 @@ namespace TestableHttpClient
         /// <param name="headerName">The name of the header that is expected.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName) => WithHeader(check, headerName, (int?)null);
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name. Values are ignored.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int numberOfRequests) => WithHeader(check, headerName, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -237,8 +311,18 @@ namespace TestableHttpClient
         /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue) => WithHeader(check, headerName, headerValue, (int?)null);
+
+        /// <summary>
+        /// Asserts whether requests were made with a specific header name and value.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="headerName">The name of the header that is expected.</param>
+        /// <param name="headerValue">The value of the expected header, supports wildcards.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int numberOfRequests) => WithHeader(check, headerName, headerValue, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithHeader(this IHttpRequestMessagesCheck check, string headerName, string headerValue, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -265,8 +349,17 @@ namespace TestableHttpClient
         /// <param name="pattern">The expected content, supports wildcards.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern) => WithContent(check, pattern, null);
+
+        /// <summary>
+        /// Asserts whether requests were made with specific content.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="pattern">The expected content, supports wildcards.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int numberOfRequests) => WithContent(check, pattern, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithContent(this IHttpRequestMessagesCheck check, string pattern, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -288,8 +381,17 @@ namespace TestableHttpClient
         /// <param name="jsonObject">The object representation of the expected request content.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject) => WithJsonContent(check, jsonObject, null);
+
+        /// <summary>
+        /// Asserts wheter requests are made with specific json content.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="jsonObject">The object representation of the expected request content.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int numberOfRequests) => WithJsonContent(check, jsonObject, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithJsonContent(this IHttpRequestMessagesCheck check, object? jsonObject, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -307,8 +409,17 @@ namespace TestableHttpClient
         /// <param name="nameValueCollection">The collection of key/value pairs that should be url encoded.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection) => WithFormUrlEncodedContent(check, nameValueCollection, null);
+
+        /// <summary>
+        /// Asserts wheter requests are made with specific url encoded content.
+        /// </summary>
+        /// <param name="check">The implementation that hold all the request messages.</param>
+        /// <param name="nameValueCollection">The collection of key/value pairs that should be url encoded.</param>
+        /// <param name="numberOfRequests">The expected number of requests.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int numberOfRequests) => WithFormUrlEncodedContent(check, nameValueCollection, (int?)numberOfRequests);
-        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int? numberOfRequests)
+
+        private static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int? numberOfRequests)
         {
             if (check == null)
             {
@@ -323,7 +434,7 @@ namespace TestableHttpClient
             using var content = new FormUrlEncodedContent(nameValueCollection);
             var contentString = content.ReadAsStringAsync().Result;
 
-            return check.With(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), numberOfRequests,$"form url encoded content '{contentString}'");
+            return check.With(x => x.HasContent(contentString) && x.HasContentHeader("Content-Type", "application/x-www-form-urlencoded*"), numberOfRequests, $"form url encoded content '{contentString}'");
         }
     }
 }

--- a/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
+++ b/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
@@ -15,7 +15,7 @@ namespace TestableHttpClient
         /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
         /// <param name="condition">The name of the conditon, used in the exception message.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition);
+        IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, string condition);
 
         /// <summary>
         /// Asserts whether requests comply with a specific filter.
@@ -24,7 +24,7 @@ namespace TestableHttpClient
         /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <param name="condition">The name of the conditon, used in the exception message.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition);
+        IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition);
 
         /// <summary>
         /// Asserts whether requests comply with a specific filter.
@@ -33,7 +33,7 @@ namespace TestableHttpClient
         /// <param name="expectedNumberOfRequests">The expected number of requests, when null is passed "at least one" is presumed.</param>
         /// <param name="condition">The name of the conditon, used in the exception message.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition);
+        IHttpRequestMessagesCheck WithFilter(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition);
 
         /// <summary>
         /// Asserts that a specific amount of requests were made.

--- a/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
+++ b/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
@@ -17,10 +17,20 @@ namespace TestableHttpClient
         IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition);
 
         /// <summary>
+        /// Asserts whether requests comply with a specific filter.
+        /// </summary>
+        /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
+        /// <param name="condition">The name of the conditon, used in the exception message.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
+        IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition);
+
+        /// <summary>
         /// Asserts that a specific amount of requests were made.
         /// </summary>
         /// <param name="count">The number of requests that are expected, should be a positive value.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         IHttpRequestMessagesCheck Times(int count);
     }
 }

--- a/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
+++ b/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Net.Http;
 
 namespace TestableHttpClient
@@ -9,6 +8,17 @@ namespace TestableHttpClient
     /// </summary>
     public interface IHttpRequestMessagesCheck
     {
+        /// <summary>
+        /// Asserts whether requests comply with a specific filter.
+        /// </summary>
+        /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
+        /// <param name="condition">The name of the conditon, used in the exception message.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
+        [Obsolete("With is a language keyword and should be avoided, use WithFilter instead.", true)]
+#pragma warning disable CA1716 // Identifiers should not match keywords
+        IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, string condition);
+#pragma warning restore CA1716 // Identifiers should not match keywords
+
         /// <summary>
         /// Asserts whether requests comply with a specific filter.
         /// </summary>

--- a/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
+++ b/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
@@ -26,7 +26,13 @@ namespace TestableHttpClient
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition);
 
-        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        /// <summary>
+        /// Asserts whether requests comply with a specific filter.
+        /// </summary>
+        /// <param name="requestFilter">The filter to filter requests with before asserting.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests, when null is passed "at least one" is presumed.</param>
+        /// <param name="condition">The name of the conditon, used in the exception message.</param>
+        /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition);
 
         /// <summary>

--- a/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
+++ b/src/TestableHttpClient/IHttpRequestMessagesCheck.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Net.Http;
 
 namespace TestableHttpClient
@@ -24,6 +25,9 @@ namespace TestableHttpClient
         /// <param name="condition">The name of the conditon, used in the exception message.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
         IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int expectedNumberOfRequests, string condition);
+
+        [EditorBrowsable(EditorBrowsableState.Advanced)]
+        IHttpRequestMessagesCheck With(Func<HttpRequestMessage, bool> requestFilter, int? expectedNumberOfRequests, string condition);
 
         /// <summary>
         /// Asserts that a specific amount of requests were made.

--- a/test/TestableHttpClient.IntegrationTests/AssertingRequests.cs
+++ b/test/TestableHttpClient.IntegrationTests/AssertingRequests.cs
@@ -180,7 +180,7 @@ namespace TestableHttpClient.IntegrationTests
 
             _ = await client.PostAsync("https://httpbin.org/post", new StringContent("", Encoding.UTF8, "application/json"));
 
-            testHandler.ShouldHaveMadeRequests().With(x => x.HasContentHeader("Content-Type", "application/json") || x.HasContentHeader("Content-Type", "application/json; *"), "");
+            testHandler.ShouldHaveMadeRequests().WithFilter(x => x.HasContentHeader("Content-Type", "application/json") || x.HasContentHeader("Content-Type", "application/json; *"), "");
         }
     }
 }

--- a/test/TestableHttpClient.IntegrationTests/AssertingRequestsWithNFluent.cs
+++ b/test/TestableHttpClient.IntegrationTests/AssertingRequestsWithNFluent.cs
@@ -182,7 +182,7 @@ namespace TestableHttpClient.IntegrationTests
 
             _ = await client.PostAsync("https://httpbin.org/post", new StringContent("", Encoding.UTF8, "application/json"));
 
-            Check.That(testHandler).HasMadeRequests().With(x => x.HasContentHeader("Content-Type", "application/json") || x.HasContentHeader("Content-Type", "application/json; *"), "");
+            Check.That(testHandler).HasMadeRequests().WithFilter(x => x.HasContentHeader("Content-Type", "application/json") || x.HasContentHeader("Content-Type", "application/json; *"), "");
         }
     }
 }

--- a/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
+++ b/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
@@ -28,7 +28,7 @@ namespace TestableHttpClient.NFluent.Tests
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
             Check.ThatCode(() => sut.With(null, "check"))
                 .IsAFailingCheckWithMessage("",
-                "The predicate should not be null.");
+                "The request filter should not be null.");
         }
 #nullable restore
 
@@ -67,7 +67,7 @@ namespace TestableHttpClient.NFluent.Tests
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
             Check.ThatCode(() => sut.With(null, 1, "check"))
                 .IsAFailingCheckWithMessage("",
-                "The predicate should not be null.");
+                "The request filter should not be null.");
         }
 #nullable restore
 

--- a/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
+++ b/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
@@ -26,7 +26,7 @@ namespace TestableHttpClient.NFluent.Tests
         public void With_NullPredicate_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
-            Check.ThatCode(() => sut.With(null, "check"))
+            Check.ThatCode(() => sut.WithFilter(null, "check"))
                 .IsAFailingCheckWithMessage("",
                 "The request filter should not be null.");
         }
@@ -37,7 +37,7 @@ namespace TestableHttpClient.NFluent.Tests
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            Check.ThatCode(() => sut.With(x => x == null, string.Empty))
+            Check.ThatCode(() => sut.WithFilter(x => x == null, string.Empty))
                 .IsAFailingCheckWithMessage("",
                 "Expected at least one request to be made, but no requests were made.");
         }
@@ -47,7 +47,7 @@ namespace TestableHttpClient.NFluent.Tests
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            Check.ThatCode(() => sut.With(x => x == null, "custom check"))
+            Check.ThatCode(() => sut.WithFilter(x => x == null, "custom check"))
                 .IsAFailingCheckWithMessage("",
                 "Expected at least one request to be made with custom check, but no requests were made.");
         }
@@ -57,7 +57,7 @@ namespace TestableHttpClient.NFluent.Tests
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            Check.ThatCode(() => sut.With(x => x != null, string.Empty)).Not.IsAFailingCheck();
+            Check.ThatCode(() => sut.WithFilter(x => x != null, string.Empty)).Not.IsAFailingCheck();
         }
 
 #nullable disable
@@ -65,7 +65,7 @@ namespace TestableHttpClient.NFluent.Tests
         public void With_WithRequestExpectations_NullPredicate_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
-            Check.ThatCode(() => sut.With(null, 1, "check"))
+            Check.ThatCode(() => sut.WithFilter(null, 1, "check"))
                 .IsAFailingCheckWithMessage("",
                 "The request filter should not be null.");
         }
@@ -76,7 +76,7 @@ namespace TestableHttpClient.NFluent.Tests
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            Check.ThatCode(() => sut.With(x => x == null, 1, string.Empty))
+            Check.ThatCode(() => sut.WithFilter(x => x == null, 1, string.Empty))
                 .IsAFailingCheckWithMessage("",
                 "Expected one request to be made, but no requests were made.");
         }
@@ -86,7 +86,7 @@ namespace TestableHttpClient.NFluent.Tests
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            Check.ThatCode(() => sut.With(x => x == null, 1, "custom check"))
+            Check.ThatCode(() => sut.WithFilter(x => x == null, 1, "custom check"))
                 .IsAFailingCheckWithMessage("",
                 "Expected one request to be made with custom check, but no requests were made.");
         }
@@ -96,7 +96,7 @@ namespace TestableHttpClient.NFluent.Tests
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            Check.ThatCode(() => sut.With(x => x != null, 1, string.Empty)).Not.IsAFailingCheck();
+            Check.ThatCode(() => sut.WithFilter(x => x != null, 1, string.Empty)).Not.IsAFailingCheck();
         }
 
         [Fact]

--- a/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
+++ b/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
@@ -23,7 +23,7 @@ namespace TestableHttpClient.NFluent.Tests
 
 #nullable disable
         [Fact]
-        public void When_NullPredicate_Fails()
+        public void With_NullPredicate_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
             Check.ThatCode(() => sut.With(null, "check"))
@@ -33,7 +33,7 @@ namespace TestableHttpClient.NFluent.Tests
 #nullable restore
 
         [Fact]
-        public void When_PredicateThatDoesNotMatchAnyRequests_Fails()
+        public void With_PredicateThatDoesNotMatchAnyRequests_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -43,7 +43,7 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void When_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_FailsWithMessage()
+        public void With_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_FailsWithMessage()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -53,14 +53,54 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void When_PredicateThatDoesMatchAnyRequests_DoesNotFail()
+        public void With_PredicateThatDoesMatchAnyRequests_DoesNotFail()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
             Check.ThatCode(() => sut.With(x => x != null, string.Empty)).Not.IsAFailingCheck();
         }
 
+#nullable disable
         [Fact]
+        public void With_WithRequestExpectations_NullPredicate_Fails()
+        {
+            var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
+            Check.ThatCode(() => sut.With(null, 1, "check"))
+                .IsAFailingCheckWithMessage("",
+                "The predicate should not be null.");
+        }
+#nullable restore
+
+        [Fact]
+        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequests_Fails()
+        {
+            var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            Check.ThatCode(() => sut.With(x => x == null, 1, string.Empty))
+                .IsAFailingCheckWithMessage("",
+                "Expected one request to be made, but no requests were made.");
+        }
+
+        [Fact]
+        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_FailsWithMessage()
+        {
+            var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            Check.ThatCode(() => sut.With(x => x == null, 1, "custom check"))
+                .IsAFailingCheckWithMessage("",
+                "Expected one request to be made with custom check, but no requests were made.");
+        }
+
+        [Fact]
+        public void With_WithRequestExpectation_PredicateThatDoesMatchAnyRequests_DoesNotFail()
+        {
+            var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            Check.ThatCode(() => sut.With(x => x != null, 1, string.Empty)).Not.IsAFailingCheck();
+        }
+
+        [Fact]
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public void Times_NegativeNumber_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
@@ -72,6 +112,7 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public void Times_MatchingNumber_DoesNotFail()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
@@ -79,6 +120,7 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public void Times_NotMatchingNumber_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());

--- a/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
+++ b/test/TestableHttpClient.NFluent.Tests/FluentHttpRequestMessagesChecksTests.cs
@@ -23,7 +23,7 @@ namespace TestableHttpClient.NFluent.Tests
 
 #nullable disable
         [Fact]
-        public void With_NullPredicate_Fails()
+        public void WithFilter_NullPredicate_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
             Check.ThatCode(() => sut.WithFilter(null, "check"))
@@ -33,7 +33,7 @@ namespace TestableHttpClient.NFluent.Tests
 #nullable restore
 
         [Fact]
-        public void With_PredicateThatDoesNotMatchAnyRequests_Fails()
+        public void WithFilter_PredicateThatDoesNotMatchAnyRequests_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -43,7 +43,7 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void With_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_FailsWithMessage()
+        public void WithFilter_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_FailsWithMessage()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -53,7 +53,7 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void With_PredicateThatDoesMatchAnyRequests_DoesNotFail()
+        public void WithFilter_PredicateThatDoesMatchAnyRequests_DoesNotFail()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -62,7 +62,7 @@ namespace TestableHttpClient.NFluent.Tests
 
 #nullable disable
         [Fact]
-        public void With_WithRequestExpectations_NullPredicate_Fails()
+        public void WithFilter_WithRequestExpectations_NullPredicate_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(Enumerable.Empty<HttpRequestMessage>());
             Check.ThatCode(() => sut.WithFilter(null, 1, "check"))
@@ -72,7 +72,7 @@ namespace TestableHttpClient.NFluent.Tests
 #nullable restore
 
         [Fact]
-        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequests_Fails()
+        public void WithFilter_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequests_Fails()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -82,7 +82,7 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_FailsWithMessage()
+        public void WithFilter_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_FailsWithMessage()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -92,7 +92,7 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void With_WithRequestExpectation_PredicateThatDoesMatchAnyRequests_DoesNotFail()
+        public void WithFilter_WithRequestExpectation_PredicateThatDoesMatchAnyRequests_DoesNotFail()
         {
             var sut = new FluentHttpRequestMessagesChecks(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 

--- a/test/TestableHttpClient.Tests/HttpRequestMessageAsserterTests.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessageAsserterTests.cs
@@ -65,7 +65,7 @@ namespace TestableHttpClient.Tests
         public void With_NullPredicate_ThrowsArgumentNullException()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.With(null, "check"));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithFilter(null, "check"));
             Assert.Equal("predicate", exception.ParamName);
         }
 #nullable restore
@@ -75,7 +75,7 @@ namespace TestableHttpClient.Tests
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, string.Empty));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFilter(x => x == null, string.Empty));
             Assert.Equal("Expected at least one request to be made, but no requests were made.", exception.Message);
         }
 
@@ -84,7 +84,7 @@ namespace TestableHttpClient.Tests
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, "custom check"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFilter(x => x == null, "custom check"));
             Assert.Equal("Expected at least one request to be made with custom check, but no requests were made.", exception.Message);
         }
 
@@ -93,7 +93,7 @@ namespace TestableHttpClient.Tests
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            sut.With(x => x != null, string.Empty);
+            sut.WithFilter(x => x != null, string.Empty);
         }
 
 #nullable disable
@@ -101,7 +101,7 @@ namespace TestableHttpClient.Tests
         public void With_WithRequestExpectations_NullPredicate_ThrowsArgumentNullException()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
-            Assert.Throws<ArgumentNullException>("predicate", () => sut.With(null, 1, "check"));
+            Assert.Throws<ArgumentNullException>("predicate", () => sut.WithFilter(null, 1, "check"));
         }
 #nullable restore
 
@@ -110,7 +110,7 @@ namespace TestableHttpClient.Tests
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, 1, string.Empty));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFilter(x => x == null, 1, string.Empty));
             Assert.Equal("Expected one request to be made, but no requests were made.", exception.Message);
         }
 
@@ -119,7 +119,7 @@ namespace TestableHttpClient.Tests
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, 1, "custom check"));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFilter(x => x == null, 1, "custom check"));
             Assert.Equal("Expected one request to be made with custom check, but no requests were made.", exception.Message);
         }
 
@@ -128,7 +128,7 @@ namespace TestableHttpClient.Tests
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
-            sut.With(x => x != null, 1, string.Empty);
+            sut.WithFilter(x => x != null, 1, string.Empty);
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessageAsserterTests.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessageAsserterTests.cs
@@ -62,7 +62,7 @@ namespace TestableHttpClient.Tests
 
 #nullable disable
         [Fact]
-        public void With_NullPredicate_ThrowsArgumentNullException()
+        public void WithFilter_NullPredicate_ThrowsArgumentNullException()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
             var exception = Assert.Throws<ArgumentNullException>(() => sut.WithFilter(null, "check"));
@@ -71,7 +71,7 @@ namespace TestableHttpClient.Tests
 #nullable restore
 
         [Fact]
-        public void With_PredicateThatDoesNotMatchAnyRequests_ThrowsAssertionException()
+        public void WithFilter_PredicateThatDoesNotMatchAnyRequests_ThrowsAssertionException()
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -80,7 +80,7 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
-        public void With_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_ThrowsAssertionException()
+        public void WithFilter_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_ThrowsAssertionException()
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -89,7 +89,7 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
-        public void With_PredicateThatDoesMatchAnyRequests_DoesNotThrow()
+        public void WithFilter_PredicateThatDoesMatchAnyRequests_DoesNotThrow()
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -98,7 +98,7 @@ namespace TestableHttpClient.Tests
 
 #nullable disable
         [Fact]
-        public void With_WithRequestExpectations_NullPredicate_ThrowsArgumentNullException()
+        public void WithFilter_WithRequestExpectations_NullPredicate_ThrowsArgumentNullException()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
             Assert.Throws<ArgumentNullException>("predicate", () => sut.WithFilter(null, 1, "check"));
@@ -106,7 +106,7 @@ namespace TestableHttpClient.Tests
 #nullable restore
 
         [Fact]
-        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequests_ThrowsAssertionException()
+        public void WithFilter_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequests_ThrowsAssertionException()
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -115,7 +115,7 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
-        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_ThrowsAssertionException()
+        public void WithFilter_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_ThrowsAssertionException()
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 
@@ -124,7 +124,7 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
-        public void With_WithRequestExpectation_PredicateThatDoesMatchAnyRequests_DoesNotThrow()
+        public void WithFilter_WithRequestExpectation_PredicateThatDoesMatchAnyRequests_DoesNotThrow()
         {
             var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
 

--- a/test/TestableHttpClient.Tests/HttpRequestMessageAsserterTests.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessageAsserterTests.cs
@@ -17,6 +17,7 @@ namespace TestableHttpClient.Tests
 #nullable restore
 
         [Fact]
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public void Times_ValueLessThan0_ThrowsArgumentException()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
@@ -27,6 +28,7 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public void Times_NoRequestsAndCount1_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
@@ -37,6 +39,7 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public void Times_NoRequestsAndCount2_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
@@ -47,6 +50,7 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
+        [Obsolete("Times as a seperate check is no longer supported, use the With overload with expectdNumberOfRequests.")]
         public void Times_NoRequestsAndCount0_ReturnsHttpRequestMessageAsserter()
         {
             var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
@@ -54,6 +58,77 @@ namespace TestableHttpClient.Tests
             var result = sut.Times(0);
             Assert.NotNull(result);
             Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
+#nullable disable
+        [Fact]
+        public void With_NullPredicate_ThrowsArgumentNullException()
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.With(null, "check"));
+            Assert.Equal("predicate", exception.ParamName);
+        }
+#nullable restore
+
+        [Fact]
+        public void With_PredicateThatDoesNotMatchAnyRequests_ThrowsAssertionException()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, string.Empty));
+            Assert.Equal("Expected at least one request to be made, but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void With_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_ThrowsAssertionException()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, "custom check"));
+            Assert.Equal("Expected at least one request to be made with custom check, but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void With_PredicateThatDoesMatchAnyRequests_DoesNotThrow()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            sut.With(x => x != null, string.Empty);
+        }
+
+#nullable disable
+        [Fact]
+        public void With_WithRequestExpectations_NullPredicate_ThrowsArgumentNullException()
+        {
+            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            Assert.Throws<ArgumentNullException>("predicate", () => sut.With(null, 1, "check"));
+        }
+#nullable restore
+
+        [Fact]
+        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequests_ThrowsAssertionException()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, 1, string.Empty));
+            Assert.Equal("Expected one request to be made, but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void With_WithRequestExpectation_PredicateThatDoesNotMatchAnyRequestsAndMessageIsGiven_ThrowsAssertionException()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.With(x => x == null, 1, "custom check"));
+            Assert.Equal("Expected one request to be made with custom check, but no requests were made.", exception.Message);
+        }
+
+        [Fact]
+        public void With_WithRequestExpectation_PredicateThatDoesMatchAnyRequests_DoesNotThrow()
+        {
+            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, "https://example.com") });
+
+            sut.With(x => x != null, 1, string.Empty);
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/Its.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/Its.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Net.Http;
+
+using Moq;
+
+namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
+{
+    public static class Its
+    {
+        public static Func<HttpRequestMessage, bool> AnyPredicate()
+        {
+            return It.IsAny<Func<HttpRequestMessage, bool>>();
+        }
+    }
+}

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContent.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContent.cs
@@ -37,7 +37,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContent(null));
 
             Assert.Equal("pattern", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Fact]
@@ -48,7 +48,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContent(null, 1));
 
             Assert.Equal("pattern", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -59,7 +59,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithContent("some content");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "content 'some content'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "content 'some content'"));
         }
 
         [Fact]
@@ -69,7 +69,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithContent("some content", 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "content 'some content'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "content 'some content'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContentHeaderName.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContentHeaderName.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader(headerName));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader(headerName, 1));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -63,7 +63,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithContentHeader("Content-Type");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "content header 'Content-Type'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "content header 'Content-Type'"));
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithContentHeader("Content-Type", 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "content header 'Content-Type'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "content header 'Content-Type'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContentHeaderName.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContentHeaderName.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Net.Http;
+
+using Moq;
 
 using Xunit;
 
@@ -10,7 +10,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
     {
 #nullable disable
         [Fact]
-        public void WithContentHeader_NullCheck_ThrowsArgumentNullException()
+        public void WithContentHeader_WithoutNumberOfRequests_NullCheck_ThrowsArgumentNullException()
         {
             IHttpRequestMessagesCheck sut = null;
 
@@ -19,52 +19,61 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             Assert.Equal("check", exception.ParamName);
         }
 
+        [Fact]
+        public void WithContentHeader_WithNumberOfRequests_NullCheck_ThrowsArgumentNullException()
+        {
+            IHttpRequestMessagesCheck sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithContentHeader("someHeader", 1));
+
+            Assert.Equal("check", exception.ParamName);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void WithContentHeader_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        public void WithContentHeader_WithoutNumberOfRequests_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithContentHeader(headerName));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader(headerName));
 
             Assert.Equal("headerName", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithContentHeader_WithNumberOfRequests_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader(headerName, 1));
+
+            Assert.Equal("headerName", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
         [Fact]
-        public void WithContentHeader_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithContentHeader_WithoutNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("Content-Type"));
+            sut.Object.WithContentHeader("Content-Type");
 
-            Assert.Equal("Expected at least one request to be made with content header 'Content-Type', but no requests were made.", exception.Message);
+            sut.Verify(x => x.With(Its.AnyPredicate(), null, "content header 'Content-Type'"));
         }
 
         [Fact]
-        public void WithContentHeader_NoMatchingRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithContentHeader_WithNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage() });
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithContentHeader("Content-Type"));
+            sut.Object.WithContentHeader("Content-Type", 1);
 
-            Assert.Equal("Expected at least one request to be made with content header 'Content-Type', but no requests were made.", exception.Message);
-        }
-
-        [Fact]
-        public void WithContentHeader_MatchingRequest_ReturnsHttpRequestMessageAsserter()
-        {
-            var request = new HttpRequestMessage
-            {
-                Content = new StringContent("")
-            };
-            var sut = new HttpRequestMessageAsserter(new[] { request });
-
-            var result = sut.WithContentHeader("Content-Type");
-
-            Assert.NotNull(result);
-            Assert.IsType<HttpRequestMessageAsserter>(result);
+            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "content header 'Content-Type'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContentHeaderNameAndValue.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithContentHeaderNameAndValue.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader(headerName, "someValue"));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader(headerName, "someValue", 1));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader("someHeader", headerValue));
 
             Assert.Equal("headerValue", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithContentHeader("someHeader", headerValue, 1));
 
             Assert.Equal("headerValue", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -89,7 +89,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithContentHeader("someHeader", "someValue");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "content header 'someHeader' and value 'someValue'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "content header 'someHeader' and value 'someValue'"));
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithContentHeader("someHeader", "someValue", 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "content header 'someHeader' and value 'someValue'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "content header 'someHeader' and value 'someValue'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithFormUrlEncodedContent.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithFormUrlEncodedContent.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 
+using Moq;
+
 using Xunit;
 
 namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
@@ -12,7 +14,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
     {
 #nullable disable
         [Fact]
-        public void WithFormUrlEncodedContent_NulCheck_ThrowsArgumentNullException()
+        public void WithFormUrlEncodedContent_WithoutNumberOfRequests_NulCheck_ThrowsArgumentNullException()
         {
             IHttpRequestMessagesCheck sut = null;
 
@@ -20,23 +22,62 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             Assert.Equal("check", exception.ParamName);
         }
-        [Fact]
-        public void WithFormUrlEncodedContent_NullNameValueCollection_ThrowsArgumentNullException()
-        {
-            var request = new HttpRequestMessage
-            {
-                Content = new FormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string, string>>())
-            };
-            var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithFormUrlEncodedContent(null));
+        [Fact]
+        public void WithFormUrlEncodedContent_WithNumberOfRequests_NulCheck_ThrowsArgumentNullException()
+        {
+            IHttpRequestMessagesCheck sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithFormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string, string>>(), 1));
+
+            Assert.Equal("check", exception.ParamName);
+        }
+
+        [Fact]
+        public void WithFormUrlEncodedContent_WithoutNumberOfRequests_NullNameValueCollection_ThrowsArgumentNullException()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithFormUrlEncodedContent(null));
 
             Assert.Equal("nameValueCollection", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public void WithFormUrlEncodedContent_WithNumberOfRequests_NullNameValueCollection_ThrowsArgumentNullException()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithFormUrlEncodedContent(null, 1));
+
+            Assert.Equal("nameValueCollection", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
         [Fact]
-        public void WithFormUrlEncodedContent_RequestWithMatchingContent_ReturnsHttpRequestMessageAsserter()
+        public void WithFormUrlEncodedContent_WithoutNumberOfRequests_CallsWithCorrectly()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            sut.Object.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" });
+
+            sut.Verify(x => x.With(Its.AnyPredicate(), null, "form url encoded content 'username=alice'"));
+        }
+
+        [Fact]
+        public void WithFormUrlEncodedContent_WithNumberOfRequests_CallsWithCorrectly()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            sut.Object.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" }, 1);
+
+            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "form url encoded content 'username=alice'"));
+        }
+
+        [Fact]
+        public void WithFormUrlEncodedContent_WithoutNumberOfRequests_RequestWithMatchingContent_ReturnsHttpRequestMessageAsserter()
         {
             var request = new HttpRequestMessage
             {
@@ -51,7 +92,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         }
 
         [Fact]
-        public void WithFormUrlEncodedContent_RequestWithNotMatchingContent_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithFormUrlEncodedContent_WithoutNumberOfRequests_RequestWithNotMatchingContent_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var request = new HttpRequestMessage
             {
@@ -65,7 +106,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         }
 
         [Fact]
-        public void WithFormUrlEncodedContent_RequestWithNotMatchingContentType_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithFormUrlEncodedContent_WithoutNumberOfRequests_RequestWithNotMatchingContentType_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
         {
             var request = new HttpRequestMessage
             {

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithFormUrlEncodedContent.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithFormUrlEncodedContent.cs
@@ -41,7 +41,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithFormUrlEncodedContent(null));
 
             Assert.Equal("nameValueCollection", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Fact]
@@ -52,7 +52,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithFormUrlEncodedContent(null, 1));
 
             Assert.Equal("nameValueCollection", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -63,7 +63,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" });
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "form url encoded content 'username=alice'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "form url encoded content 'username=alice'"));
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" }, 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "form url encoded content 'username=alice'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "form url encoded content 'username=alice'"));
         }
 
         [Fact]

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHeaderName.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHeaderName.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHeader(headerName));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHeader(headerName, 1));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -63,7 +63,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHeader("Content-Type");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "header 'Content-Type'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "header 'Content-Type'"));
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHeader("Content-Type", 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "header 'Content-Type'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "header 'Content-Type'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHeaderNameAndValue.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHeaderNameAndValue.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHeader(headerName, "someValue"));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHeader(headerName, "someValue", 1));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHeader("someHeader", headerValue));
 
             Assert.Equal("headerValue", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHeader("someHeader", headerValue, 1));
 
             Assert.Equal("headerValue", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -89,7 +89,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHeader("someHeader", "someValue");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "header 'someHeader' and value 'someValue'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "header 'someHeader' and value 'someValue'"));
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHeader("someHeader", "someValue", 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "header 'someHeader' and value 'someValue'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "header 'someHeader' and value 'someValue'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHttpMethod.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHttpMethod.cs
@@ -38,7 +38,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHttpMethod(null));
 
             Assert.Equal("httpMethod", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHttpMethod(null, 1));
 
             Assert.Equal("httpMethod", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -60,7 +60,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHttpMethod(HttpMethod.Get);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "HTTP Method 'GET'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "HTTP Method 'GET'"));
         }
 
         [Fact]
@@ -70,7 +70,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHttpMethod(HttpMethod.Get, 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "HTTP Method 'GET'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "HTTP Method 'GET'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHttpVersion.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHttpVersion.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Linq;
 using System.Net;
-using System.Net.Http;
+
+using Moq;
 
 using Xunit;
 
@@ -11,7 +11,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
     {
 #nullable disable
         [Fact]
-        public void WithHttpVersion_NullCheck_ThrowsArgumentNulLException()
+        public void WithHttpVersion_WithoutNumberOfRequests_NullCheck_ThrowsArgumentNulLException()
         {
             IHttpRequestMessagesCheck sut = null;
             var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHttpVersion(HttpVersion.Version11));
@@ -20,45 +20,55 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         }
 
         [Fact]
-        public void WithHttpVersion_NullHttpVersion_ThrowsArgumentNullException()
+        public void WithHttpVersion_WithNumberOfRequests_NullCheck_ThrowsArgumentNulLException()
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            IHttpRequestMessagesCheck sut = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHttpVersion(HttpVersion.Version11, 1));
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithHttpVersion(null));
+            Assert.Equal("check", exception.ParamName);
+        }
+
+        [Fact]
+        public void WithHttpVersion_WithoutNumberOfRequests_NullHttpVersion_ThrowsArgumentNullException()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHttpVersion(null));
 
             Assert.Equal("httpVersion", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Fact]
+        public void WithHttpVersion_WithNumberOfRequests_NullHttpVersion_ThrowsArgumentNullException()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHttpVersion(null, 1));
+
+            Assert.Equal("httpVersion", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
         [Fact]
-        public void WithHttpVersion_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithHttpVersion_WithoutNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHttpVersion(HttpVersion.Version11));
+            sut.Object.WithHttpVersion(HttpVersion.Version11);
 
-            Assert.Equal("Expected at least one request to be made with HTTP Version '1.1', but no requests were made.", exception.Message);
+            sut.Verify(x => x.With(Its.AnyPredicate(), null, "HTTP Version '1.1'"));
         }
 
         [Fact]
-        public void WithHttpVersion_RequestsWithIncorrectHttpVersion_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithHttpVersion_WithNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage { Version = HttpVersion.Version20 } });
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithHttpVersion(HttpVersion.Version11));
+            sut.Object.WithHttpVersion(HttpVersion.Version11, 1);
 
-            Assert.Equal("Expected at least one request to be made with HTTP Version '1.1', but no requests were made.", exception.Message);
-        }
-
-        [Fact]
-        public void WithHttpVersion_RequestsWithCorrectVersion_ReturnsHttpRequestMessageAsserter()
-        {
-            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage { Version = HttpVersion.Version11 } });
-
-            var result = sut.WithHttpVersion(HttpVersion.Version11);
-
-            Assert.NotNull(result);
-            Assert.IsType<HttpRequestMessageAsserter>(result);
+            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "HTTP Version '1.1'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHttpVersion.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithHttpVersion.cs
@@ -36,7 +36,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHttpVersion(null));
 
             Assert.Equal("httpVersion", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithHttpVersion(null, 1));
 
             Assert.Equal("httpVersion", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -58,7 +58,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHttpVersion(HttpVersion.Version11);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "HTTP Version '1.1'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "HTTP Version '1.1'"));
         }
 
         [Fact]
@@ -68,7 +68,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithHttpVersion(HttpVersion.Version11, 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "HTTP Version '1.1'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "HTTP Version '1.1'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithJsonContent.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithJsonContent.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithJsonContent(null);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "json content 'null'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "json content 'null'"));
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithJsonContent(null, 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "json content 'null'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "json content 'null'"));
         }
 
         [Fact]

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithJsonContent.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithJsonContent.cs
@@ -2,6 +2,8 @@
 using System.Net.Http;
 using System.Text;
 
+using Moq;
+
 using Xunit;
 
 namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
@@ -10,7 +12,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
     {
 #nullable disable
         [Fact]
-        public void WithJsonContent_NullChecker_ThrowsArgumentNullException()
+        public void WithJsonContent_WithoutNumberOfRequests_NullChecker_ThrowsArgumentNullException()
         {
             IHttpRequestMessagesCheck sut = null;
 
@@ -18,7 +20,37 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             Assert.Equal("check", exception.ParamName);
         }
+
+        [Fact]
+        public void WithJsonContent_WithNumberOfRequests_NullChecker_ThrowsArgumentNullException()
+        {
+            IHttpRequestMessagesCheck sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithJsonContent(null, 1));
+
+            Assert.Equal("check", exception.ParamName);
+        }
 #nullable restore
+
+        [Fact]
+        public void WithJsonContent_WithoutNumberOfRequests_CallsWithCorrectly()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            sut.Object.WithJsonContent(null);
+
+            sut.Verify(x => x.With(Its.AnyPredicate(), null, "json content 'null'"));
+        }
+
+        [Fact]
+        public void WithJsonContent_WithNumberOfRequests_CallsWithCorrectly()
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            sut.Object.WithJsonContent(null, 1);
+
+            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "json content 'null'"));
+        }
 
         [Fact]
         public void WithJsonContent_RequestWithMatchingContent_ReturnsHttpRequestMessageAsserter()

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderName.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderName.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName, 1));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -63,7 +63,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithRequestHeader("api-version");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "request header 'api-version'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "request header 'api-version'"));
         }
 
         [Fact]
@@ -73,7 +73,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithRequestHeader("api-version", 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "request header 'api-version'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "request header 'api-version'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderName.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderName.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Net.Http;
+
+using Moq;
 
 using Xunit;
 
@@ -10,7 +10,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
     {
 #nullable disable
         [Fact]
-        public void WithRequestHeader_NullCheck_ThrowsArgumentNullException()
+        public void WithRequestHeader_WithoutNumberOfRequests_NullCheck_ThrowsArgumentNullException()
         {
             IHttpRequestMessagesCheck sut = null;
 
@@ -19,50 +19,61 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             Assert.Equal("check", exception.ParamName);
         }
 
+        [Fact]
+        public void WithRequestHeader_WithNumberOfRequests_NullCheck_ThrowsArgumentNullException()
+        {
+            IHttpRequestMessagesCheck sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader("someHeader", 1));
+
+            Assert.Equal("check", exception.ParamName);
+        }
+
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void WithRequestHeader_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        public void WithRequestHeader_WithoutNumberOfRequests_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader(headerName));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName));
 
             Assert.Equal("headerName", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithRequestHeader_WithNumberOfRequests_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName, 1));
+
+            Assert.Equal("headerName", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
         [Fact]
-        public void WithRequestHeader_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeader_WithoutNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version"));
+            sut.Object.WithRequestHeader("api-version");
 
-            Assert.Equal("Expected at least one request to be made with request header 'api-version', but no requests were made.", exception.Message);
+            sut.Verify(x => x.With(Its.AnyPredicate(), null, "request header 'api-version'"));
         }
 
         [Fact]
-        public void WithRequestHeader_NoMatchingRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeader_WithNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage() });
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version"));
+            sut.Object.WithRequestHeader("api-version", 1);
 
-            Assert.Equal("Expected at least one request to be made with request header 'api-version', but no requests were made.", exception.Message);
-        }
-
-        [Fact]
-        public void WithRequestHeader_MatchingRequest_ReturnsHttpRequestMessageAsserter()
-        {
-            var request = new HttpRequestMessage();
-            request.Headers.Add("api-version", "1.0");
-            var sut = new HttpRequestMessageAsserter(new[] { request });
-
-            var result = sut.WithRequestHeader("api-version");
-
-            Assert.NotNull(result);
-            Assert.IsType<HttpRequestMessageAsserter>(result);
+            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "request header 'api-version'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderNameAndValue.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderNameAndValue.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName, "someValue"));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -52,7 +52,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName, "someValue", 1));
 
             Assert.Equal("headerName", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -65,7 +65,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader("someHeader", headerValue));
 
             Assert.Equal("headerValue", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 
         [Theory]
@@ -78,7 +78,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader("someHeader", headerValue, 1));
 
             Assert.Equal("headerValue", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -89,7 +89,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithRequestHeader("someHeader", "someValue");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "request header 'someHeader' and value 'someValue'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "request header 'someHeader' and value 'someValue'"));
         }
 
         [Fact]
@@ -99,7 +99,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithRequestHeader("someHeader", "someValue", 1);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "request header 'someHeader' and value 'someValue'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "request header 'someHeader' and value 'someValue'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderNameAndValue.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestHeaderNameAndValue.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Net.Http;
+
+using Moq;
 
 using Xunit;
 
@@ -10,7 +10,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
     {
 #nullable disable
         [Fact]
-        public void WithRequestHeaderNameAndValue_NullCheck_ThrowsArgumentNullException()
+        public void WithRequestHeaderNameAndValue_WithoutNumberOfRequests_NullCheck_ThrowsArgumentNullException()
         {
             IHttpRequestMessagesCheck sut = null;
 
@@ -19,87 +19,87 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             Assert.Equal("check", exception.ParamName);
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        public void WithRequestHeaderNameAndValue_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        [Fact]
+        public void WithRequestHeaderNameAndValue_WithNumberOfRequests_NullCheck_ThrowsArgumentNullException()
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            IHttpRequestMessagesCheck sut = null;
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader(headerName, "someValue"));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader("someHeader", "someValue", 1));
 
-            Assert.Equal("headerName", exception.ParamName);
+            Assert.Equal("check", exception.ParamName);
         }
 
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        public void WithRequestHeaderNameAndValue_NullOrEmptyValue_ThrowsArgumentNullException(string headerValue)
+        public void WithRequestHeaderNameAndValue_WithoutNumberOfRequests_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestHeader("someHeader", headerValue));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName, "someValue"));
+
+            Assert.Equal("headerName", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithRequestHeaderNameAndValue_WithNumberOfRequests_NullOrEmptyHeaderName_ThrowsArgumentNullException(string headerName)
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader(headerName, "someValue", 1));
+
+            Assert.Equal("headerName", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithRequestHeaderNameAndValue_WithoutNumberOfRequests_NullOrEmptyValue_ThrowsArgumentNullException(string headerValue)
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader("someHeader", headerValue));
 
             Assert.Equal("headerValue", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void WithRequestHeaderNameAndValue_WithNumberOfRequests_NullOrEmptyValue_ThrowsArgumentNullException(string headerValue)
+        {
+            var sut = new Mock<IHttpRequestMessagesCheck>();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestHeader("someHeader", headerValue, 1));
+
+            Assert.Equal("headerValue", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
         [Fact]
-        public void WithRequestHeaderNameAndValue_NoRequests_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeaderNameAndValue_WithoutNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("someHeader", "someValue"));
+            sut.Object.WithRequestHeader("someHeader", "someValue");
 
-            Assert.Equal("Expected at least one request to be made with request header 'someHeader' and value 'someValue', but no requests were made.", exception.Message);
+            sut.Verify(x => x.With(Its.AnyPredicate(), null, "request header 'someHeader' and value 'someValue'"));
         }
 
         [Fact]
-        public void WithRequestHeaderNameAndValue_RequestWithoutHeaders_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestHeaderNameAndValue_WithNumberOfRequests_CallsWithCorrectly()
         {
-            var request = new HttpRequestMessage();
-            var sut = new HttpRequestMessageAsserter(new[] { request });
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version", "1.0"));
+            sut.Object.WithRequestHeader("someHeader", "someValue", 1);
 
-            Assert.Equal("Expected at least one request to be made with request header 'api-version' and value '1.0', but no requests were made.", exception.Message);
-        }
-
-        [Fact]
-        public void WithRequestHeaderNameAndValue_RequestWithNotMatchingHeaderName_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
-        {
-            var request = new HttpRequestMessage();
-            request.Headers.Add("no-api-version", "1.0");
-            var sut = new HttpRequestMessageAsserter(new[] { request });
-
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version", "1.0"));
-
-            Assert.Equal("Expected at least one request to be made with request header 'api-version' and value '1.0', but no requests were made.", exception.Message);
-        }
-
-        [Fact]
-        public void WithRequestHeaderNameAndValue_RequestWithNotMatchingHeaderValue_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
-        {
-            var request = new HttpRequestMessage();
-            request.Headers.Add("api-version", "unknown");
-            var sut = new HttpRequestMessageAsserter(new[] { request });
-
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestHeader("api-version", "1.0"));
-
-            Assert.Equal("Expected at least one request to be made with request header 'api-version' and value '1.0', but no requests were made.", exception.Message);
-        }
-
-        [Fact]
-        public void WithRequestHeaderNameAndValue_RequestWithMatchinHeader_ReturnsHttpRequestMessageAssert()
-        {
-            var request = new HttpRequestMessage();
-            request.Headers.Add("api-version", "1.0");
-            var sut = new HttpRequestMessageAsserter(new[] { request });
-
-            var result = sut.WithRequestHeader("api-version", "1.0");
-
-            Assert.NotNull(result);
-            Assert.IsType<HttpRequestMessageAsserter>(result);
+            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)1, "request header 'someHeader' and value 'someValue'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestUri.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestUri.cs
@@ -39,7 +39,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
             var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestUri(pattern));
 
             Assert.Equal("pattern", exception.ParamName);
-            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
@@ -50,7 +50,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithRequestUri("https://example.com/");
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), null, "uri pattern 'https://example.com/'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "uri pattern 'https://example.com/'"));
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
 
             sut.Object.WithRequestUri("https://example.com/", 2);
 
-            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)2, "uri pattern 'https://example.com/'"));
+            sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)2, "uri pattern 'https://example.com/'"));
         }
     }
 }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestUri.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithRequestUri.cs
@@ -1,6 +1,6 @@
 ﻿using System;
-using System.Linq;
-using System.Net.Http;
+
+using Moq;
 
 using Xunit;
 
@@ -10,11 +10,21 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
     {
 #nullable disable
         [Fact]
-        public void WithRequestUri_NullCheck_ThrowsArgumentNullException()
+        public void WithRequestUri_WithoutNumberOfRequests_NullCheck_ThrowsArgumentNullException()
         {
             IHttpRequestMessagesCheck sut = null;
 
             var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestUri("*"));
+
+            Assert.Equal("check", exception.ParamName);
+        }
+
+        [Fact]
+        public void WithRequestUri_WithNumberOfRequests_NullCheck_ThrowsArgumentNullException()
+        {
+            IHttpRequestMessagesCheck sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestUri("*", 2));
 
             Assert.Equal("check", exception.ParamName);
         }
@@ -24,47 +34,33 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         [InlineData("")]
         public void WithRequestUri_NullOrEmptyPattern_ThrowsArgumentNullException(string pattern)
         {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<ArgumentNullException>(() => sut.WithRequestUri(pattern));
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.Object.WithRequestUri(pattern));
 
             Assert.Equal("pattern", exception.ParamName);
+            sut.Verify(x => x.With(Its.AnyPredicate(), It.IsAny<int?>(), It.IsAny<string>()), Times.Never());
         }
 #nullable restore
 
         [Fact]
-        public void WithRequestUri_RequestWithMatchingUri_DoesNotThrowException()
+        public void WithRequestUri_WithoutNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, new Uri("https://example.com/")) });
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            sut.WithRequestUri("https://example.com/");
+            sut.Object.WithRequestUri("https://example.com/");
+
+            sut.Verify(x => x.With(Its.AnyPredicate(), null, "uri pattern 'https://example.com/'"));
         }
 
         [Fact]
-        public void WithRequestUri_RequestWithMatchingUriAndNegationTurnedOn_ThrowsHttpRequestMessageAssertionExceptionWithSpecificMessage()
+        public void WithRequestUri_WithNumberOfRequests_CallsWithCorrectly()
         {
-            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, new Uri("https://example.com/")) }, true);
+            var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestUri("https://example.com/"));
-            Assert.Equal("Expected no requests to be made with uri pattern 'https://example.com/', but one request was made.", exception.Message);
-        }
+            sut.Object.WithRequestUri("https://example.com/", 2);
 
-        [Fact]
-        public void WithRequestUri_RequestWithNotMatchingUri_ThrowsHttpRequestMessageassertionExceptionWithSpecificMessage()
-        {
-            var sut = new HttpRequestMessageAsserter(new[] { new HttpRequestMessage(HttpMethod.Get, new Uri("https://example.com/")) });
-
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestUri("https://test.org/"));
-            Assert.Equal("Expected at least one request to be made with uri pattern 'https://test.org/', but no requests were made.", exception.Message);
-        }
-
-        [Fact]
-        public void WithRequestUri_RequestWithStarPatternAndNoRequests_ThrowsHttpRequestMessageassertionExceptionWithSpecificMessage()
-        {
-            var sut = new HttpRequestMessageAsserter(Enumerable.Empty<HttpRequestMessage>());
-
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithRequestUri("*"));
-            Assert.Equal("Expected at least one request to be made, but no requests were made.", exception.Message);
+            sut.Verify(x => x.With(Its.AnyPredicate(), (int?)2, "uri pattern 'https://example.com/'"));
         }
     }
 }


### PR DESCRIPTION
This Pull request provides the following changes:

- the `With()` method is renamed to `WithFilter()` since `With` is a language keyword.
- the `Times()` method is replaced by an overload on the `WithFilter()` method that accepts an integer to indicate the exact number of requests expected.
- an extra overload for WithFilter is added that accepts a nullable integer. Passing `null` indicates that at least 1 request is expected, passing a number indicates the exact number of requests that are expected.
- all existing `With*()` methods also received the an overload that accepts an integer to indicate the exact number of expected requests.

Note that both the `With` and `Times` methods will be removed in the release after 0.5

Fixes #47 
