### PR TITLE
Fix HasContent on .NET 5.

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "dotnet-format": {
-      "version": "3.3.111304",
+      "version": "4.1.131201",
       "commands": [
         "dotnet-format"
       ]
     },
     "dotnet-sonarscanner": {
-      "version": "4.9.0",
+      "version": "5.0.4",
       "commands": [
         "dotnet-sonarscanner"
       ]
     },
     "gitversion.tool": {
-      "version": "5.3.6",
+      "version": "5.5.0",
       "commands": [
         "dotnet-gitversion"
       ]

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,6 +18,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
+    - name: Setup .NET Core 3.1
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '3.1'
     - name: Setup .NET Core 5.0
       uses: actions/setup-dotnet@v1
       with:
@@ -31,7 +35,7 @@ jobs:
     - name: Build source code
       run: dotnet build --configuration Release --no-restore
     - name: Test with dotnet
-      run: dotnet test --configuration Release --no-build --collect="Code Coverage" --framework="net5.0"
+      run: dotnet test --configuration Release --no-build --collect="Code Coverage" --framework="netcoreapp3.1"
     - name: Upload sonarqube results
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -41,7 +41,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: dotnet sonarscanner end -d:sonar.login=${{secrets.SONARCLOUD_TOKEN}}
     - name: Check source file format
-      run: dotnet format --folder . --check --dry-run # --folder is used to supress warnings: https://github.com/dotnet/format/issues/584
+      run: dotnet format --check
     - name: Pack
       run: dotnet pack --output ./artifacts --configuration Release --no-build
     - uses: actions/upload-artifact@v2

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -18,10 +18,10 @@ jobs:
       uses: actions/checkout@v2
     - name: Fetch all history for all tags and branches
       run: git fetch --prune --unshallow
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET Core 5.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1'
+        dotnet-version: '5.0'
     - name: Restore dotnet tools
       run: dotnet tool restore
     - name: Prepare sonarqube
@@ -31,7 +31,7 @@ jobs:
     - name: Build source code
       run: dotnet build --configuration Release --no-restore
     - name: Test with dotnet
-      run: dotnet test --configuration Release --no-build --collect="Code Coverage" --framework="netcoreapp3.1"
+      run: dotnet test --configuration Release --no-build --collect="Code Coverage" --framework="net5.0"
     - name: Upload sonarqube results
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -64,6 +64,10 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '3.1'
+    - name: Setup .NET Core 5.0
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '5.0'
     - name: Restore dependencies
       run: dotnet restore
     - name: Build source code
@@ -78,10 +82,10 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Setup .NET Core 3.1
+    - name: Setup .NET Core 5.0
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: '3.1'
+        dotnet-version: '5.0'
     - uses: actions/download-artifact@v2
       with:
         name: artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [unreleased]
 ### Changed
-- TestableHttpClient is now being tested against multiple .net versions, currently these are: .net core 2.1 and .net core 3.1.
+- TestableHttpClient is now being tested against multiple .net versions, currently these are: .NET Core 2.1, .NET Core 3.1 and .NET 5.0.
+- `HasContent()` and `HasContent(string)` now return `false` when the actual content results in an empty string.
 
 ## [0.5] - 2020-06-25
 ### Deprecated

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,6 +29,5 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-    <AdditionalFiles Include="$(MSBuildThisFileDirectory)/.editorconfig" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ var result = await httpClient.GetAsync("http://httpbin.org/status/200");
 Check.That(testHandler).HasMadeRequestsTo("https://httpbin.org/*");
 ```
 
+## Supported .NET versions
+
+TestableHttpClient is build as a netstandard2.0 library, so theoretically it can work on every .NET version that support netstandard2.0.
+However, only the following versions are being actively tested and thus supported:
+
+- .NET Core 2.1
+- .NET Core 3.1
+- .NET 5.0
+
+These versions are supported as long as Microsoft supports them, we do our best to test and support newer versions as soon as possible.
+
 ## Contributing
 
 Please read [CONTRIBUTING.md](CONTRIBUTING.md) for details on how you can help us out.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,16 +4,6 @@
 
 Currently only the latest version of NuGet packages will receive vulnerability updates.
 
-## Supported .NET versions
-
-TestableHttpClient is build as a netstandard2.0 library, so theoretically it can work on every .NET version that support netstandard2.0.
-However, only the following versions are being actively tested and thus supported:
-
-- .NET Core 2.1
-- .NET Core 3.1
-
-These versions are supported as long as Microsoft supports them, we do our best to test and support newer versions as soon as possible.
-
 ## Reporting a Vulnerability
 
 Vulnerabilities in the libraries can be reported via an issue on GitHub. A PR to fix the issue is always welcome.

--- a/src/TestableHttpClient.NFluent/HttpResponseMessageChecks.cs
+++ b/src/TestableHttpClient.NFluent/HttpResponseMessageChecks.cs
@@ -146,15 +146,6 @@ namespace TestableHttpClient.NFluent
             return ExtensibilityHelper.BuildCheckLink(check);
         }
 
-        private static IEnumerable<KeyValuePair<string, IEnumerable<string>>> GetHeaders(this HttpContent httpContent)
-        {
-            if (httpContent == null)
-            {
-                return Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
-            }
-            return httpContent.Headers;
-        }
-
         /// <summary>
         /// Verify that the response has a content header with a given name and value.
         /// </summary>
@@ -173,6 +164,15 @@ namespace TestableHttpClient.NFluent
                 .HasHeaderWithValue(expectedHeader, expectedValue);
 
             return ExtensibilityHelper.BuildCheckLink(check);
+        }
+
+        private static IEnumerable<KeyValuePair<string, IEnumerable<string>>> GetHeaders(this HttpContent httpContent)
+        {
+            if (httpContent == null)
+            {
+                return Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
+            }
+            return httpContent.Headers;
         }
 
         private static void HasHeaderWithValue(this ICheckLogic<IEnumerable<Header>> checkLogic, string expectedHeader, string expectedValue)

--- a/src/TestableHttpClient.NFluent/HttpResponseMessageChecks.cs
+++ b/src/TestableHttpClient.NFluent/HttpResponseMessageChecks.cs
@@ -135,17 +135,24 @@ namespace TestableHttpClient.NFluent
             ExtensibilityHelper.BeginCheck(check)
                 .SetSutName("response")
                 .FailIfNull()
-#pragma warning disable CS8602 // Dereference of a possibly null reference. Justification = "Null reference check is performed by the FailIfNull check"
-                .CheckSutAttributes(sut => sut.Content, "content")
+#pragma warning disable CS8602 // Dereference of a possibly null reference. Justification: Null check is performed in FailIfNull statement
+                .CheckSutAttributes(sut => sut.Content.GetHeaders().Select(x => x.Key).ToArray(), "content's headers")
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
-                .FailIfNull()
-                .CheckSutAttributes(sut => sut.Headers.Select(x => x.Key).ToArray(), "headers")
                 .FailWhen(sut => !sut.Contains(expectedHeader), "The {0} does not contain the expected header.")
                 .DefineExpectedResult(expectedHeader, "The expected header:", "The forbidden header:")
                 .OnNegate("The {0} should not contain the forbidden header.")
                 .EndCheck();
 
             return ExtensibilityHelper.BuildCheckLink(check);
+        }
+
+        private static IEnumerable<KeyValuePair<string, IEnumerable<string>>> GetHeaders(this HttpContent httpContent)
+        {
+            if (httpContent == null)
+            {
+                return Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>();
+            }
+            return httpContent.Headers;
         }
 
         /// <summary>
@@ -160,11 +167,9 @@ namespace TestableHttpClient.NFluent
             ExtensibilityHelper.BeginCheck(check)
                 .SetSutName("response")
                 .FailIfNull()
-#pragma warning disable CS8602 // Dereference of a possibly null reference. Justification = "Null reference check is performed by the FailIfNull check"
-                .CheckSutAttributes(sut => sut.Content, "content")
+#pragma warning disable CS8602 // Dereference of a possibly null reference. Justification: Null check is performed in FailIfNull statement
+                .CheckSutAttributes(sut => sut.Content.GetHeaders().Select(x => new Header(x.Key, x.Value)), "content's headers")
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
-                .FailIfNull()
-                .CheckSutAttributes(sut => sut.Headers.Select(x => new Header(x.Key, x.Value)), "headers")
                 .HasHeaderWithValue(expectedHeader, expectedValue);
 
             return ExtensibilityHelper.BuildCheckLink(check);
@@ -200,12 +205,22 @@ namespace TestableHttpClient.NFluent
                 .SetSutName("response")
                 .FailIfNull()
 #pragma warning disable CS8602 // Dereference of a possibly null reference. Justification = "Null reference check is performed by the FailIfNull check"
-                .FailWhen(sut => sut.Content == null, "The {0} has no content, but content was expected.", MessageOption.NoCheckedBlock | MessageOption.NoExpectedBlock)
+                .FailWhen(sut => !sut.Content.HasContent(), "The {0} has no content, but content was expected.", MessageOption.NoCheckedBlock | MessageOption.NoExpectedBlock)
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
                 .OnNegate("The {0} has content, but no content was expected.", MessageOption.NoCheckedBlock | MessageOption.NoExpectedBlock)
                 .EndCheck();
 
             return ExtensibilityHelper.BuildCheckLink(check);
+        }
+
+        private static bool HasContent(this HttpContent httpContent)
+        {
+            if (httpContent == null)
+            {
+                return false;
+            }
+            var stream = httpContent.ReadAsStreamAsync().Result;
+            return stream.ReadByte() != -1;
         }
 
         /// <summary>
@@ -230,9 +245,9 @@ namespace TestableHttpClient.NFluent
             else if (expectedContent.Contains("*"))
             {
 #pragma warning disable CS8602 // Dereference of a possibly null reference. Justification = "Null reference check is performed by the FailIfNull check"
-                checkLogic.CheckSutAttributes(sut => sut.Content?.ReadAsStringAsync()?.Result, "content")
+                checkLogic.CheckSutAttributes(sut => sut.Content?.ReadAsStringAsync()?.Result ?? string.Empty, "content")
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
-                .FailWhen(sut => sut == null || !StringMatcher.Matches(sut, expectedContent), "The {0} does not match the expected pattern.")
+                .FailWhen(sut => !StringMatcher.Matches(sut, expectedContent), "The {0} does not match the expected pattern.")
                 .DefineExpectedResult(expectedContent, "The expected content pattern:", "The forbidden content pattern:")
                 .OnNegate("The {0} should not match the forbidden pattern.")
                 .EndCheck();
@@ -240,9 +255,9 @@ namespace TestableHttpClient.NFluent
             else
             {
 #pragma warning disable CS8602 // Dereference of a possibly null reference. Justification = "Null reference check is performed by the FailIfNull check"
-                checkLogic.CheckSutAttributes(sut => sut.Content?.ReadAsStringAsync()?.Result, "content")
+                checkLogic.CheckSutAttributes(sut => sut.Content?.ReadAsStringAsync()?.Result ?? string.Empty, "content")
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
-                .FailWhen(sut => sut == null || !StringMatcher.Matches(sut, expectedContent), "The {0} should be the expected content.")
+                .FailWhen(sut => !StringMatcher.Matches(sut, expectedContent), "The {0} should be the expected content.")
                 .DefineExpectedResult(expectedContent, "The expected content:", "The forbidden content:")
                 .OnNegate("The {0} should not be the forbidden content.")
                 .EndCheck();

--- a/src/TestableHttpClient/HttpRequestMessageAssertionException.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAssertionException.cs
@@ -1,19 +1,12 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
-using System.Runtime.Serialization;
 
 namespace TestableHttpClient
 {
-    [Serializable]
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Not intended for public usage, but could be used for catching.")]
     public sealed class HttpRequestMessageAssertionException : Exception
     {
         internal HttpRequestMessageAssertionException(string message) : base(message)
-        {
-        }
-
-        private HttpRequestMessageAssertionException(SerializationInfo serializationInfo, StreamingContext streamingContext)
-            : base(serializationInfo, streamingContext)
         {
         }
     }

--- a/src/TestableHttpClient/HttpRequestMessageAssertionException.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAssertionException.cs
@@ -1,12 +1,19 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Runtime.Serialization;
 
 namespace TestableHttpClient
 {
+    [Serializable]
     [SuppressMessage("Design", "CA1032:Implement standard exception constructors", Justification = "Not intended for public usage, but could be used for catching.")]
     public sealed class HttpRequestMessageAssertionException : Exception
     {
         internal HttpRequestMessageAssertionException(string message) : base(message)
+        {
+        }
+
+        [ExcludeFromCodeCoverage]
+        private HttpRequestMessageAssertionException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
     }

--- a/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
+++ b/src/TestableHttpClient/HttpRequestMessagesCheckExtensions.cs
@@ -408,7 +408,7 @@ namespace TestableHttpClient
         /// <param name="check">The implementation that hold all the request messages.</param>
         /// <param name="nameValueCollection">The collection of key/value pairs that should be url encoded.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection) => WithFormUrlEncodedContent(check, nameValueCollection, null);
+        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string?, string?>> nameValueCollection) => WithFormUrlEncodedContent(check, nameValueCollection, null);
 
         /// <summary>
         /// Asserts wheter requests are made with specific url encoded content.
@@ -417,9 +417,9 @@ namespace TestableHttpClient
         /// <param name="nameValueCollection">The collection of key/value pairs that should be url encoded.</param>
         /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
         /// <returns>The <seealso cref="IHttpRequestMessagesCheck"/> for further assertions.</returns>
-        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int expectedNumberOfRequests) => WithFormUrlEncodedContent(check, nameValueCollection, (int?)expectedNumberOfRequests);
+        public static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string?, string?>> nameValueCollection, int expectedNumberOfRequests) => WithFormUrlEncodedContent(check, nameValueCollection, (int?)expectedNumberOfRequests);
 
-        private static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string, string>> nameValueCollection, int? expectedNumberOfRequests)
+        private static IHttpRequestMessagesCheck WithFormUrlEncodedContent(this IHttpRequestMessagesCheck check, IEnumerable<KeyValuePair<string?, string?>> nameValueCollection, int? expectedNumberOfRequests)
         {
             if (check == null)
             {

--- a/src/TestableHttpClient/HttpResponseMessageExtensions.cs
+++ b/src/TestableHttpClient/HttpResponseMessageExtensions.cs
@@ -219,8 +219,8 @@ namespace TestableHttpClient
             }
 
             var stringContent = string.Empty;
-            
-            if(httpResponseMessage.Content != null)
+
+            if (httpResponseMessage.Content != null)
             {
                 stringContent = httpResponseMessage.Content.ReadAsStringAsync().Result;
             }

--- a/src/TestableHttpClient/HttpResponseMessageExtensions.cs
+++ b/src/TestableHttpClient/HttpResponseMessageExtensions.cs
@@ -190,7 +190,14 @@ namespace TestableHttpClient
             {
                 throw new ArgumentNullException(nameof(httpResponseMessage));
             }
-            return httpResponseMessage.Content != null;
+
+            if (httpResponseMessage.Content == null)
+            {
+                return false;
+            }
+
+            var stream = httpResponseMessage.Content.ReadAsStreamAsync().Result;
+            return stream.ReadByte() != -1;
         }
 
         /// <summary>
@@ -211,12 +218,7 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            if (httpResponseMessage.Content == null)
-            {
-                return false;
-            }
-
-            var stringContent = httpResponseMessage.Content.ReadAsStringAsync().Result;
+            var stringContent = httpResponseMessage.Content?.ReadAsStringAsync()?.Result ?? string.Empty;
 
             return pattern switch
             {

--- a/src/TestableHttpClient/HttpResponseMessageExtensions.cs
+++ b/src/TestableHttpClient/HttpResponseMessageExtensions.cs
@@ -218,7 +218,12 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            var stringContent = httpResponseMessage.Content?.ReadAsStringAsync()?.Result ?? string.Empty;
+            var stringContent = string.Empty;
+            
+            if(httpResponseMessage.Content != null)
+            {
+                stringContent = httpResponseMessage.Content.ReadAsStringAsync().Result;
+            }
 
             return pattern switch
             {

--- a/test/TestableHttpClient.IntegrationTests/CreatingClients.cs
+++ b/test/TestableHttpClient.IntegrationTests/CreatingClients.cs
@@ -15,18 +15,22 @@ namespace TestableHttpClient.IntegrationTests
 
             await client.GetAsync("https://httpbin.org/get");
 
+#if NETCOREAPP2_1
+            testableHttpMessageHandler.ShouldHaveMadeRequests().WithHttpVersion(HttpVersion.Version20);
+#else
             testableHttpMessageHandler.ShouldHaveMadeRequests().WithHttpVersion(HttpVersion.Version11);
+#endif
         }
 
         [Fact]
         public async Task CreateClientWithConfiguration()
         {
             var testableHttpMessageHandler = new TestableHttpMessageHandler();
-            var client = testableHttpMessageHandler.CreateClient(client => client.DefaultRequestVersion = HttpVersion.Version20);
+            var client = testableHttpMessageHandler.CreateClient(client => client.DefaultRequestHeaders.Add("test", "test"));
 
             await client.GetAsync("https://httpbin.org/get");
 
-            testableHttpMessageHandler.ShouldHaveMadeRequests().WithHttpVersion(HttpVersion.Version20);
+            testableHttpMessageHandler.ShouldHaveMadeRequests().WithRequestHeader("test", "test");
         }
     }
 }

--- a/test/TestableHttpClient.IntegrationTests/TestableHttpClient.IntegrationTests.csproj
+++ b/test/TestableHttpClient.IntegrationTests/TestableHttpClient.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/test/TestableHttpClient.IntegrationTests/TestableHttpClient.IntegrationTests.csproj
+++ b/test/TestableHttpClient.IntegrationTests/TestableHttpClient.IntegrationTests.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include=".editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.5" Condition="'$(TargetFramework)' != 'netcoreapp2.1'" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">

--- a/test/TestableHttpClient.IntegrationTests/UsingIHttpClientFactory.cs
+++ b/test/TestableHttpClient.IntegrationTests/UsingIHttpClientFactory.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿#if !NETCOREAPP2_1
+using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -126,3 +127,4 @@ namespace TestableHttpClient.IntegrationTests
         }
     }
 }
+#endif

--- a/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContent.cs
+++ b/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContent.cs
@@ -34,11 +34,26 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void HasContent_WhenContentIsNotNull_DoesNotFail()
+        public void HasContent_WhenContentIsNullAndNotEmpty_DoesFail()
         {
             using var sut = new HttpResponseMessage
             {
                 Content = new StringContent("")
+            };
+
+            Check.ThatCode(() => Check.That(sut).HasContent())
+                .IsAFailingCheckWithMessage(
+                    "",
+                    "The checked response has no content, but content was expected."
+                );
+        }
+
+        [Fact]
+        public void HasContent_WhenContentIsNotEmpty_DoesNotFail()
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("Some Content")
             };
 
             Check.That(sut).HasContent();
@@ -53,11 +68,22 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void HasContent_WhenContentIsNotNullAndNotIsUsed_DoesFail()
+        public void HasContent_WhenContentIsEmptyAndNotIsUsed_DoesNotFail()
         {
             using var sut = new HttpResponseMessage
             {
                 Content = new StringContent("")
+            };
+
+            Check.That(sut).Not.HasContent();
+        }
+
+        [Fact]
+        public void HasContent_WhenContentIsNotNullAndNotIsUsed_DoesFail()
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("Some content")
             };
 
             Check.ThatCode(() => Check.That(sut).Not.HasContent())

--- a/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContentHeader.cs
+++ b/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContentHeader.cs
@@ -32,7 +32,11 @@ namespace TestableHttpClient.NFluent.Tests
             Check.ThatCode(() => Check.That(sut).HasContentHeader("Content-Disposition"))
                 .IsAFailingCheckWithMessage(
                     "",
-                    "The checked response's content is null."
+                    "The checked response's content's headers does not contain the expected header.",
+                    "The checked response's content's headers:",
+                    "\t{} (0 item)",
+                    "The expected header:",
+                    "\t[\"Content-Disposition\"]"
                 );
         }
 

--- a/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContentHeaderWithPattern.cs
+++ b/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContentHeaderWithPattern.cs
@@ -32,7 +32,11 @@ namespace TestableHttpClient.NFluent.Tests
             Check.ThatCode(() => Check.That(sut).HasContentHeader("Content-Disposition", "inline"))
                 .IsAFailingCheckWithMessage(
                     "",
-                    "The checked response's content is null."
+                    "The checked response's content's headers does not contain the expected header.",
+                    "The checked response's content's headers:",
+                    "\t{} (0 item)",
+                    "The expected header:",
+                    "\t[Content-Disposition: inline]"
                 );
         }
 

--- a/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContentWithPattern.cs
+++ b/test/TestableHttpClient.NFluent.Tests/HttpResponseMessageChecksTests.HasContentWithPattern.cs
@@ -11,7 +11,7 @@ namespace TestableHttpClient.NFluent.Tests
     public partial class HttpResponseMessageChecksTests
     {
         [Fact]
-        public void HasContentWithPattern_WhenHttpResponseMessageIsNull_DoesFail()
+        public void HasContentWithEmptyPattern_WhenHttpResponseMessageIsNull_DoesFail()
         {
             HttpResponseMessage? sut = null;
 
@@ -23,18 +23,37 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
-        public void HasContentWithPattern_WhenContentIsNull_DoesFail()
+        public void HasContentWithEmptyPattern_WhenContentIsNull_DoesNotFail()
         {
             using var sut = new HttpResponseMessage();
 
-            Check.ThatCode(() => Check.That(sut).HasContent(""))
+            Check.That(sut).HasContent("");
+        }
+
+        [Fact]
+        public void HasContentWithEmptyPattern_WhenContentIsEmpty_DoesNotFail()
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("")
+            };
+
+            Check.That(sut).HasContent("");
+        }
+
+        [Fact]
+        public void HasContentWithEmptyPattern_WhenContentIsNull_DoesFail()
+        {
+            using var sut = new HttpResponseMessage();
+
+            Check.ThatCode(() => Check.That(sut).HasContent("Some content"))
                 .IsAFailingCheckWithMessage(
                     "",
                     "The checked response's content should be the expected content.",
                     "The checked response's content:",
-                    "\t[null]",
+                    "\t[\"\"]",
                     "The expected content:",
-                    "\t[\"\"]"
+                    "\t[\"Some content\"]"
                 );
         }
 
@@ -66,7 +85,15 @@ namespace TestableHttpClient.NFluent.Tests
         {
             using var sut = new HttpResponseMessage();
 
-            Check.That(sut).Not.HasContent("");
+            Check.ThatCode(() => Check.That(sut).Not.HasContent(""))
+                .IsAFailingCheckWithMessage(
+                    "",
+                    "The checked response's content should not be the forbidden content.",
+                    "The checked response's content:",
+                    $"\t[\"\"]",
+                    "The forbidden content:",
+                    $"\t[\"\"]"
+                );
         }
 
         [Theory]

--- a/test/TestableHttpClient.NFluent.Tests/TestableHttpClient.NFluent.Tests.csproj
+++ b/test/TestableHttpClient.NFluent.Tests/TestableHttpClient.NFluent.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/TestableHttpClient.NFluent.Tests/TestableHttpClient.NFluent.Tests.csproj
+++ b/test/TestableHttpClient.NFluent.Tests/TestableHttpClient.NFluent.Tests.csproj
@@ -5,10 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include=".editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/test/TestableHttpClient.Tests/HttpRequestMessageAssertionExceptionTests.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessageAssertionExceptionTests.cs
@@ -1,7 +1,4 @@
-﻿using System.IO;
-using System.Runtime.Serialization.Formatters.Binary;
-
-using Xunit;
+﻿using Xunit;
 
 namespace TestableHttpClient.Tests
 {
@@ -12,23 +9,6 @@ namespace TestableHttpClient.Tests
         {
             var exception = new HttpRequestMessageAssertionException("My exception");
 
-            Assert.Equal("My exception", exception.Message);
-        }
-
-        [Fact]
-        public void Serialization_Works()
-        {
-            var sut = new HttpRequestMessageAssertionException("My exception");
-
-            using var stream = new MemoryStream();
-            var formatter = new BinaryFormatter();
-            formatter.Serialize(stream, sut);
-
-            stream.Seek(0, SeekOrigin.Begin);
-
-            var output = formatter.Deserialize(stream);
-
-            var exception = Assert.IsType<HttpRequestMessageAssertionException>(output);
             Assert.Equal("My exception", exception.Message);
         }
     }

--- a/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithFormUrlEncodedContent.cs
+++ b/test/TestableHttpClient.Tests/HttpRequestMessagesExtensionsTests/WithFormUrlEncodedContent.cs
@@ -61,7 +61,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         {
             var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            sut.Object.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" });
+            sut.Object.WithFormUrlEncodedContent(new[] { new KeyValuePair<string?, string?>("username", "alice") });
 
             sut.Verify(x => x.WithFilter(Its.AnyPredicate(), null, "form url encoded content 'username=alice'"));
         }
@@ -71,7 +71,7 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         {
             var sut = new Mock<IHttpRequestMessagesCheck>();
 
-            sut.Object.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" }, 1);
+            sut.Object.WithFormUrlEncodedContent(new[] { new KeyValuePair<string?, string?>("username", "alice") }, 1);
 
             sut.Verify(x => x.WithFilter(Its.AnyPredicate(), (int?)1, "form url encoded content 'username=alice'"));
         }
@@ -81,11 +81,11 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         {
             var request = new HttpRequestMessage
             {
-                Content = new FormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string, string>>())
+                Content = new FormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string?, string?>>())
             };
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var result = sut.WithFormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string, string>>());
+            var result = sut.WithFormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string?, string?>>());
 
             Assert.NotNull(result);
             Assert.IsType<HttpRequestMessageAsserter>(result);
@@ -96,11 +96,11 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         {
             var request = new HttpRequestMessage
             {
-                Content = new FormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string, string>>())
+                Content = new FormUrlEncodedContent(Enumerable.Empty<KeyValuePair<string?, string?>>())
             };
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" }));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFormUrlEncodedContent(new[] { new KeyValuePair<string?, string?>("username", "alice") }));
 
             Assert.Equal("Expected at least one request to be made with form url encoded content 'username=alice', but no requests were made.", exception.Message);
         }
@@ -110,12 +110,12 @@ namespace TestableHttpClient.Tests.HttpRequestMessagesExtensionsTests
         {
             var request = new HttpRequestMessage
             {
-                Content = new FormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" })
+                Content = new FormUrlEncodedContent(new[] { new KeyValuePair<string?, string?>("username", "alice") })
             };
             request.Content.Headers.ContentType = new MediaTypeHeaderValue("plain/text");
             var sut = new HttpRequestMessageAsserter(new[] { request });
 
-            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFormUrlEncodedContent(new Dictionary<string, string> { ["username"] = "alice" }));
+            var exception = Assert.Throws<HttpRequestMessageAssertionException>(() => sut.WithFormUrlEncodedContent(new[] { new KeyValuePair<string?, string?>("username", "alice") }));
 
             Assert.Equal("Expected at least one request to be made with form url encoded content 'username=alice', but no requests were made.", exception.Message);
         }

--- a/test/TestableHttpClient.Tests/HttpResponseMessageBuilderTests.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageBuilderTests.cs
@@ -64,7 +64,7 @@ namespace TestableHttpClient.Tests
 
             var result = sut.WithResponseHeaders(x => x.Location = new Uri("https://example.com/")).Build();
 
-            Assert.Equal("https://example.com/", result.Headers.Location.AbsoluteUri);
+            Assert.Equal("https://example.com/", result.Headers.Location?.AbsoluteUri);
         }
 
         [Theory]
@@ -118,8 +118,8 @@ namespace TestableHttpClient.Tests
             var result = sut.WithStringContent("My content").Build();
 
             Assert.Equal("My content", await result.Content.ReadAsStringAsync());
-            Assert.Equal("text/plain", result.Content.Headers.ContentType.MediaType);
-            Assert.Equal("utf-8", result.Content.Headers.ContentType.CharSet);
+            Assert.Equal("text/plain", result.Content.Headers.ContentType?.MediaType);
+            Assert.Equal("utf-8", result.Content.Headers.ContentType?.CharSet);
         }
 
         [Fact]
@@ -129,8 +129,8 @@ namespace TestableHttpClient.Tests
 
             var result = sut.WithStringContent("", null).Build();
 
-            Assert.Equal("text/plain", result.Content.Headers.ContentType.MediaType);
-            Assert.Equal("utf-8", result.Content.Headers.ContentType.CharSet);
+            Assert.Equal("text/plain", result.Content.Headers.ContentType?.MediaType);
+            Assert.Equal("utf-8", result.Content.Headers.ContentType?.CharSet);
         }
 
         [Fact]
@@ -140,8 +140,8 @@ namespace TestableHttpClient.Tests
 
             var result = sut.WithStringContent("", Encoding.ASCII).Build();
 
-            Assert.Equal("text/plain", result.Content.Headers.ContentType.MediaType);
-            Assert.Equal("us-ascii", result.Content.Headers.ContentType.CharSet);
+            Assert.Equal("text/plain", result.Content.Headers.ContentType?.MediaType);
+            Assert.Equal("us-ascii", result.Content.Headers.ContentType?.CharSet);
         }
 
         [Fact]
@@ -151,8 +151,8 @@ namespace TestableHttpClient.Tests
 
             var result = sut.WithStringContent("", null, null).Build();
 
-            Assert.Equal("text/plain", result.Content.Headers.ContentType.MediaType);
-            Assert.Equal("utf-8", result.Content.Headers.ContentType.CharSet);
+            Assert.Equal("text/plain", result.Content.Headers.ContentType?.MediaType);
+            Assert.Equal("utf-8", result.Content.Headers.ContentType?.CharSet);
         }
 
         [Fact]
@@ -162,8 +162,8 @@ namespace TestableHttpClient.Tests
 
             var result = sut.WithStringContent("", null, "application/json").Build();
 
-            Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
-            Assert.Equal("utf-8", result.Content.Headers.ContentType.CharSet);
+            Assert.Equal("application/json", result.Content.Headers.ContentType?.MediaType);
+            Assert.Equal("utf-8", result.Content.Headers.ContentType?.CharSet);
         }
 
         [Fact]
@@ -174,7 +174,7 @@ namespace TestableHttpClient.Tests
             var result = sut.WithJsonContent(null).Build();
 
             Assert.Equal("null", await result.Content.ReadAsStringAsync());
-            Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
+            Assert.Equal("application/json", result.Content.Headers.ContentType?.MediaType);
         }
 
         [Fact]
@@ -185,7 +185,7 @@ namespace TestableHttpClient.Tests
             var result = sut.WithJsonContent(Array.Empty<object>(), null).Build();
 
             Assert.Equal("[]", await result.Content.ReadAsStringAsync());
-            Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
+            Assert.Equal("application/json", result.Content.Headers.ContentType?.MediaType);
         }
 
         [Fact]
@@ -196,8 +196,8 @@ namespace TestableHttpClient.Tests
             var result = sut.WithJsonContent(new { }, "text/json").Build();
 
             Assert.Equal("{}", await result.Content.ReadAsStringAsync());
-            Assert.Equal("text/json", result.Content.Headers.ContentType.MediaType);
-            Assert.Null(result.Content.Headers.ContentType.CharSet);
+            Assert.Equal("text/json", result.Content.Headers.ContentType?.MediaType);
+            Assert.Null(result.Content.Headers.ContentType?.CharSet);
         }
 
         [Fact]

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContent.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContent.cs
@@ -27,11 +27,22 @@ namespace TestableHttpClient.Tests
         }
 
         [Fact]
-        public void HasContent_NotNullContent_ReturnsTrue()
+        public void HasContent_EmptyContent_ReturnsFalse()
         {
             using var sut = new HttpResponseMessage
             {
                 Content = new StringContent("")
+            };
+
+            Assert.False(sut.HasContent());
+        }
+
+        [Fact]
+        public void HasContent_NotEmptyContent_ReturnsTrue()
+        {
+            using var sut = new HttpResponseMessage
+            {
+                Content = new StringContent("Some Content")
             };
 
             Assert.True(sut.HasContent());

--- a/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContentWithPattern.cs
+++ b/test/TestableHttpClient.Tests/HttpResponseMessageExtensionsTests.HasContentWithPattern.cs
@@ -28,11 +28,11 @@ namespace TestableHttpClient.Tests
 #nullable enable
 
         [Fact]
-        public void HasContentWithPattern_NoContent_ReturnsFalse()
+        public void HasContentWithPattern_NoContentAndEmptyPattern_ReturnsTrue()
         {
             using var sut = new HttpResponseMessage();
 
-            Assert.False(sut.HasContent(""));
+            Assert.True(sut.HasContent(""));
         }
 
         [Theory]

--- a/test/TestableHttpClient.Tests/TestableHttpClient.Tests.csproj
+++ b/test/TestableHttpClient.Tests/TestableHttpClient.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
HasContent now checks the actual content, instead of only wether or not the Content property is null. This means that `Content == null` and `Content = new StringContent("")` will behave the same way.

Fixes #64 .

** Reminder **
- Did you add unit tests?
- Did you consider adding an integration test for documentation?
- Did you follow the coding guidelines and run dotnet format?
