### PR TITLE
Adds issue-template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+ - name: GitHub Discussions
+   url: https://github.com/dnperfors/TestableHttpClient/discussions
+   about: Please ask and answer questions here

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,9 +1,0 @@
----
-name: Question
-about: Ask a question
-title: ''
-labels: question
-assignees: ''
-
----
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,12 @@
 Thank you for your willingness to help with this project. Although we are happy with all the help, we do want to set some guidelines on how to contribute to this project. By following these guidelines you can help us to manage our time and spend more time on developing this open source project.
 
 ## Do you have a question?
-- Questions can be asked via GitHub issue, using the tag "Question"
-- Please ensure the question is not already asked, by searching all issues with the "Question" tag.
-- Please close the issue yourself when the question is answered.
+- Questions can be asked via GitHub discussions.
+- Please ensure the question is not already asked, by searching all discussions.
 
 ## Did you find a bug?
 - Please make sure the bug is not already reported.
+- Not sure if it is really a bug? Ask a question first. Questions will be converted to bugs if necessary.
 - Please open a GitHub issue.
 - Add a clear title and description.
 - If possible include a simple unit test describing the bug. A few lines of code will say a lot more than a few paragraphs of text.
@@ -20,13 +20,13 @@ Thank you for your willingness to help with this project. Although we are happy 
 - Make sure there is a test that proves that the issue did exists and is now fixed.
 
 ## Did you write a patch to fix code style issues?
-Please do **not** submit a Pull Request.
+Please do **not** submit a Pull Request, a Pull Request with only code style fixes will make it harder to track who made certain changes.
 
 ## Did you want to refactor code to make it more readable and better maintainable?
-- Please open a GitHub issue to discuss it.
+- Please open a GitHub discussion to discuss it.
 - Clearly describe what you want to refactor and why.
 - Did you forget to open an issue? Please describe the reasoning in the Pull Request itself. But be advised that this could mean that you spend time refactoring and we still reject the Pull Request.
 
 ## Do you have great ideas for the project?
-- Please open a GitHub issue to discuss it.
+- Please open a GitHub issue or discussion to discuss it.
 - Do **not** open a Pull Request before discussing it.


### PR DESCRIPTION
Since GitHub Discussions is enabled, remove the question template and add config to point to the right space.
