### PR TITLE
Adds expectedNumberOfRequests parameter to several methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
+### Deprecated
+- `ShouldNotHaveMadeRequests(this TestableHttpMessageHandler)` will be removed in favour of the new `ShouldHaveMadeRequests(this HttpMessageHandler, 0)`.
+- `ShouldNotHaveMadeRequestsTo(this TestableHttpMessageHandler, string)` will be removed in favour of the new `ShouldHaveMadeRequestsTo(this HttpMessageHandler, string, 0)`.
+
 ### Added
 - `WithQueryString(this IHttpRequestMessageCheck, string)` to test the querystring without url encoding.
 - `RespondWith(Func<HttpRequestMessage, HttpResponseMessage)` to configure a factory method that is called when making a request.
+- `ShouldHaveMadeRequests(this TestableHttpMessageHandler, int)` to test that a certain amount of requests are made.
+- `ShouldHaveMadeRequestsTo(this TestableHttpMessageHandler, string, int)` to test that a certain amount of requests are made.
 
 ### Changed
 - TestableHttpClient is now being tested against multiple .net versions, currently these are: .NET Core 2.1, .NET Core 3.1 and .NET 5.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `RespondWith(Func<HttpRequestMessage, HttpResponseMessage)` to configure a factory method that is called when making a request.
 - `ShouldHaveMadeRequests(this TestableHttpMessageHandler, int)` to test that a certain amount of requests are made.
 - `ShouldHaveMadeRequestsTo(this TestableHttpMessageHandler, string, int)` to test that a certain amount of requests are made.
+- `public static IHttpRequestMessagesCheck HasMadeRequests(this ICheck<TestableHttpMessageHandler?>, int)` to test that a certain amount of requests are made.
+- `public static IHttpRequestMessagesCheck HasMadeRequestsTo(this ICheck<TestableHttpMessageHandler?>, string, int)` to test that a certain amount of requests are made.
 
 ### Changed
 - TestableHttpClient is now being tested against multiple .net versions, currently these are: .NET Core 2.1, .NET Core 3.1 and .NET 5.0.

--- a/src/TestableHttpClient.NFluent/TestableHttpClientChecks.cs
+++ b/src/TestableHttpClient.NFluent/TestableHttpClientChecks.cs
@@ -28,6 +28,22 @@ namespace TestableHttpClient.NFluent
         }
 
         /// <summary>
+        /// Verify that at least one request is made.
+        /// </summary>
+        /// <param name="check">The fluent check to be extended.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
+        /// <returns>An <see cref="IHttpRequestMessagesCheck"/> which can be used to make more specific checks.</returns>
+        public static IHttpRequestMessagesCheck HasMadeRequests(this ICheck<TestableHttpMessageHandler?> check, int expectedNumberOfRequests)
+        {
+            ExtensibilityHelper.BeginCheck(check)
+                .FailIfNull()
+                .CantBeNegated(nameof(HasMadeRequests))
+                .EndCheck();
+
+            return check.HasMadeRequestsTo("*", expectedNumberOfRequests);
+        }
+
+        /// <summary>
         /// Verify that at least one request is made to a specific url.
         /// </summary>
         /// <param name="check">The fluent check to be extended.</param>
@@ -47,6 +63,29 @@ namespace TestableHttpClient.NFluent
             }
 
             return new FluentHttpRequestMessagesChecks(requests).WithRequestUri(pattern);
+        }
+
+        /// <summary>
+        /// Verify that at least one request is made to a specific url.
+        /// </summary>
+        /// <param name="check">The fluent check to be extended.</param>
+        /// <param name="pattern">The uri pattern that is expected.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
+        /// <returns>An <see cref="IHttpRequestMessagesCheck"/> which can be used to make more specific checks.</returns>
+        public static IHttpRequestMessagesCheck HasMadeRequestsTo(this ICheck<TestableHttpMessageHandler?> check, string pattern, int expectedNumberOfRequests)
+        {
+            ExtensibilityHelper.BeginCheck(check)
+                .FailIfNull()
+                .CantBeNegated(nameof(HasMadeRequestsTo))
+                .EndCheck();
+
+            var requests = Enumerable.Empty<HttpRequestMessage>();
+            if (check is FluentSut<TestableHttpMessageHandler> checker && checker.Value != null && checker.Value.Requests != null)
+            {
+                requests = checker.Value.Requests;
+            }
+
+            return new FluentHttpRequestMessagesChecks(requests).WithRequestUri(pattern, expectedNumberOfRequests);
         }
     }
 }

--- a/src/TestableHttpClient/HttpRequestMessageAsserter.cs
+++ b/src/TestableHttpClient/HttpRequestMessageAsserter.cs
@@ -13,26 +13,14 @@ namespace TestableHttpClient
     internal class HttpRequestMessageAsserter : IHttpRequestMessagesCheck
     {
         private readonly List<string> _expectedConditions = new List<string>();
-        private readonly bool _negate;
 
         /// <summary>
         /// Construct a new HttpRequestMessageAsserter.
         /// </summary>
         /// <param name="httpRequestMessages">The list of requests to assert on.</param>
         public HttpRequestMessageAsserter(IEnumerable<HttpRequestMessage> httpRequestMessages)
-            : this(httpRequestMessages, false)
-        {
-        }
-
-        /// <summary>
-        /// Construct a new HttpRequestMessageAsserter.
-        /// </summary>
-        /// <param name="httpRequestMessages">The list of requests to assert on.</param>
-        /// <param name="negate">Whether or not all assertions should be negated.</param>
-        public HttpRequestMessageAsserter(IEnumerable<HttpRequestMessage> httpRequestMessages, bool negate)
         {
             Requests = httpRequestMessages ?? throw new ArgumentNullException(nameof(httpRequestMessages));
-            _negate = negate;
         }
 
         /// <summary>
@@ -48,15 +36,6 @@ namespace TestableHttpClient
                 null => actualCount > 0,
                 _ => actualCount == expectedCount,
             };
-
-            if (_negate)
-            {
-                if (!expectedCount.HasValue)
-                {
-                    expectedCount = 0;
-                }
-                pass = !pass;
-            }
 
             if (!pass)
             {

--- a/src/TestableHttpClient/TestableHttpMessageHandlerAssertionExtensions.cs
+++ b/src/TestableHttpClient/TestableHttpMessageHandlerAssertionExtensions.cs
@@ -22,6 +22,24 @@ namespace TestableHttpClient
         }
 
         /// <summary>
+        /// Validates that requests have been made, throws an exception when no requests were made.
+        /// </summary>
+        /// <param name="handler">The <see cref="TestableHttpMessageHandler"/> that should be asserted.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
+        /// <returns>An <see cref="IHttpRequestMessagesCheck"/> that can be used for additional assertions.</returns>
+        /// <exception cref="ArgumentNullException">handler is `null`</exception>
+        /// <exception cref="HttpRequestMessageAssertionException">When no requests are made</exception>
+        public static IHttpRequestMessagesCheck ShouldHaveMadeRequests(this TestableHttpMessageHandler handler, int expectedNumberOfRequests)
+        {
+            if (handler == null)
+            {
+                throw new ArgumentNullException(nameof(handler));
+            }
+
+            return new HttpRequestMessageAsserter(handler.Requests).WithRequestUri("*", expectedNumberOfRequests);
+        }
+
+        /// <summary>
         /// Validates that requests to a specific uri have been made, throws an exception when no requests were made.
         /// </summary>
         /// <param name="handler">The <see cref="TestableHttpMessageHandler"/> that should be asserted.</param>
@@ -45,29 +63,15 @@ namespace TestableHttpClient
         }
 
         /// <summary>
-        /// Validates that no requests have been made, throws an exception when requests were made.
-        /// </summary>
-        /// <param name="handler">The <see cref="TestableHttpMessageHandler"/> that should be asserted.</param>
-        /// <exception cref="ArgumentNullException">handler is `null`</exception>
-        /// <exception cref="HttpRequestMessageAssertionException">When requests are made</exception>
-        public static void ShouldNotHaveMadeRequests(this TestableHttpMessageHandler handler)
-        {
-            if (handler == null)
-            {
-                throw new ArgumentNullException(nameof(handler));
-            }
-
-            _ = new HttpRequestMessageAsserter(handler.Requests, true).WithRequestUri("*");
-        }
-
-        /// <summary>
-        /// Validates that no requests to a specific uri have been made, throws an exception when requests were made.
+        /// Validates that requests to a specific uri have been made, throws an exception when no requests were made.
         /// </summary>
         /// <param name="handler">The <see cref="TestableHttpMessageHandler"/> that should be asserted.</param>
         /// <param name="pattern">The uri pattern to validate against, the pattern supports *.</param>
+        /// <param name="expectedNumberOfRequests">The expected number of requests.</param>
+        /// <returns>An <see cref="IHttpRequestMessagesCheck"/> that can be used for additional assertions.</returns>
         /// <exception cref="ArgumentNullException">handler is `null` or pattern is `null`</exception>
-        /// <exception cref="HttpRequestMessageAssertionException">When requests are made</exception>
-        public static void ShouldNotHaveMadeRequestsTo(this TestableHttpMessageHandler handler, string pattern)
+        /// <exception cref="HttpRequestMessageAssertionException">When no requests are made</exception>
+        public static IHttpRequestMessagesCheck ShouldHaveMadeRequestsTo(this TestableHttpMessageHandler handler, string pattern, int expectedNumberOfRequests)
         {
             if (handler == null)
             {
@@ -79,7 +83,32 @@ namespace TestableHttpClient
                 throw new ArgumentNullException(nameof(pattern));
             }
 
-            _ = new HttpRequestMessageAsserter(handler.Requests, true).WithRequestUri(pattern);
+            return new HttpRequestMessageAsserter(handler.Requests).WithRequestUri(pattern, expectedNumberOfRequests);
+        }
+
+        /// <summary>
+        /// Validates that no requests have been made, throws an exception when requests were made.
+        /// </summary>
+        /// <param name="handler">The <see cref="TestableHttpMessageHandler"/> that should be asserted.</param>
+        /// <exception cref="ArgumentNullException">handler is `null`</exception>
+        /// <exception cref="HttpRequestMessageAssertionException">When requests are made</exception>
+        [Obsolete("This check is now replaced with `ShouldHaveMadeRequests(0)`")]
+        public static void ShouldNotHaveMadeRequests(this TestableHttpMessageHandler handler)
+        {
+            _ = handler.ShouldHaveMadeRequests(0);
+        }
+
+        /// <summary>
+        /// Validates that no requests to a specific uri have been made, throws an exception when requests were made.
+        /// </summary>
+        /// <param name="handler">The <see cref="TestableHttpMessageHandler"/> that should be asserted.</param>
+        /// <param name="pattern">The uri pattern to validate against, the pattern supports *.</param>
+        /// <exception cref="ArgumentNullException">handler is `null` or pattern is `null`</exception>
+        /// <exception cref="HttpRequestMessageAssertionException">When requests are made</exception>
+        [Obsolete("This check is now replaced with `ShouldHaveMadeRequestsTo(pattern, 0)`")]
+        public static void ShouldNotHaveMadeRequestsTo(this TestableHttpMessageHandler handler, string pattern)
+        {
+            _ = handler.ShouldHaveMadeRequestsTo(pattern, 0);
         }
     }
 }

--- a/test/TestableHttpClient.IntegrationTests/AssertingRequests.cs
+++ b/test/TestableHttpClient.IntegrationTests/AssertingRequests.cs
@@ -14,7 +14,7 @@ namespace TestableHttpClient.IntegrationTests
             var testHandler = new TestableHttpMessageHandler();
             var client = new HttpClient(testHandler);
 
-            testHandler.ShouldNotHaveMadeRequests();
+            testHandler.ShouldHaveMadeRequests(0);
             Assert.Throws<HttpRequestMessageAssertionException>(() => testHandler.ShouldHaveMadeRequests());
         }
 
@@ -27,9 +27,8 @@ namespace TestableHttpClient.IntegrationTests
             _ = await client.GetAsync("https://httpbin.org/get");
 
             testHandler.ShouldHaveMadeRequests();
-            Assert.Throws<HttpRequestMessageAssertionException>(() => testHandler.ShouldNotHaveMadeRequests());
+            Assert.Throws<HttpRequestMessageAssertionException>(() => testHandler.ShouldHaveMadeRequests(0));
         }
-
 
         [Fact]
         public async Task AssertingCallsAreNotMadeToSpecificUri()
@@ -39,8 +38,8 @@ namespace TestableHttpClient.IntegrationTests
 
             _ = await client.GetAsync("https://httpbin.org/get");
 
-            testHandler.ShouldNotHaveMadeRequestsTo("https://example.org");
-            Assert.Throws<HttpRequestMessageAssertionException>(() => testHandler.ShouldNotHaveMadeRequestsTo("https://httpbin.org/get"));
+            testHandler.ShouldHaveMadeRequestsTo("https://example.org", 0);
+            Assert.Throws<HttpRequestMessageAssertionException>(() => testHandler.ShouldHaveMadeRequestsTo("https://httpbin.org/get", 0));
         }
 
         [Fact]

--- a/test/TestableHttpClient.NFluent.Tests/TestableHttpClientChecksTests.cs
+++ b/test/TestableHttpClient.NFluent.Tests/TestableHttpClientChecksTests.cs
@@ -37,6 +37,27 @@ namespace TestableHttpClient.NFluent.Tests
         }
 
         [Fact]
+        public void HasMadeRequestsWithExpectedNumberOfRequests_NoRequestsMadeAndZeroRequestsExpeceted_Passes()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            Check.ThatCode(() => Check.That(sut).HasMadeRequests(0)).Not.IsAFailingCheck();
+        }
+
+        [Fact]
+        public void HasMadeRequestsWithExpectedNumberOfRequests_NoRequestsMadeAndOneRequestExpeceted_Passes()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            Check.ThatCode(() => Check.That(sut).HasMadeRequests(1)).IsAFailingCheck();
+        }
+
+        [Fact]
+        public void HasMadeRequestsWithExpectedNumberOfRequests_NegatedCheck_Fail()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            Check.ThatCode(() => Check.That(sut).Not.HasMadeRequests(0)).Throws<InvalidOperationException>().WithMessage("HasMadeRequests can't be used when negated");
+        }
+
+        [Fact]
         public async Task HasMadeRequestsTo_OneRequestMade_Passes()
         {
             using var sut = new TestableHttpMessageHandler();
@@ -70,6 +91,41 @@ namespace TestableHttpClient.NFluent.Tests
         {
             using var sut = new TestableHttpMessageHandler();
             Check.ThatCode(() => Check.That(sut).Not.HasMadeRequestsTo("https://httpbin.com/get")).Throws<InvalidOperationException>().WithMessage("HasMadeRequestsTo can't be used when negated");
+        }
+
+        [Fact]
+        public void HasMadeRequestsToWithExpectedNumberOfRequests_NoRequestsMadeAndZeroExpected_Passes()
+        {
+            using var sut = new TestableHttpMessageHandler();
+
+            Check.ThatCode(() => Check.That(sut).HasMadeRequestsTo("https://httpbin.com/get", 0)).Not.IsAFailingCheck();
+        }
+
+        [Fact]
+        public async Task HasMadeRequestsToWithExpectedNumberOfRequests_MatchingNumberOfRequestsMade_Passes()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            using var client = sut.CreateClient();
+
+            _ = await client.GetAsync("https://httpbin.com/get");
+            Check.ThatCode(() => Check.That(sut).HasMadeRequestsTo("https://httpbin.com/get", 1)).Not.IsAFailingCheck();
+        }
+
+        [Fact]
+        public async Task HasMadeRequestsToWithExpectedNumberOfRequests_NoMatchingNumberOfRequestsMade_Fail()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            using var client = sut.CreateClient();
+
+            _ = await client.GetAsync("https://httpbin.com/get");
+            Check.ThatCode(() => Check.That(sut).HasMadeRequestsTo("https://httpbin.com/get", 2)).IsAFailingCheck();
+        }
+
+        [Fact]
+        public void HasMadeRequestsToWithExpectedNumberOfRequests_NegatedCheck_Fail()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            Check.ThatCode(() => Check.That(sut).Not.HasMadeRequestsTo("https://httpbin.com/get", 0)).Throws<InvalidOperationException>().WithMessage("HasMadeRequestsTo can't be used when negated");
         }
     }
 }

--- a/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldHaveMadeRequests.cs
+++ b/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldHaveMadeRequests.cs
@@ -17,6 +17,15 @@ namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsT
             var exception = Assert.Throws<ArgumentNullException>(() => sut.ShouldHaveMadeRequests());
             Assert.Equal("handler", exception.ParamName);
         }
+
+        [Fact]
+        public void ShouldHaveMadeRequestWithNumberOfRequests_NullHandler_ThrowsArgumentNullException()
+        {
+            TestableHttpMessageHandler sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.ShouldHaveMadeRequests(1));
+            Assert.Equal("handler", exception.ParamName);
+        }
 #nullable restore
 
         [Fact]
@@ -28,6 +37,14 @@ namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsT
         }
 
         [Fact]
+        public void ShouldHaveMadeRequestsWithNumberOfRequests_WhenNoRequestsWereMade_ThrowsHttpRequestMessageAssertionException()
+        {
+            using var sut = new TestableHttpMessageHandler();
+
+            Assert.Throws<HttpRequestMessageAssertionException>(() => sut.ShouldHaveMadeRequests(1));
+        }
+
+        [Fact]
         public async Task ShouldHaveMadeRequests_WhenRequestsWereMade_ReturnsHttpRequestMessageAsserter()
         {
             using var sut = new TestableHttpMessageHandler();
@@ -36,6 +53,20 @@ namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsT
             _ = await client.GetAsync(new Uri("https://example.com/"));
 
             var result = sut.ShouldHaveMadeRequests();
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
+        [Fact]
+        public async Task ShouldHaveMadeRequestsWithNumberOfRequests_WhenRequestsWereMade_ReturnsHttpRequestMessageAsserter()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            using var client = new HttpClient(sut);
+
+            _ = await client.GetAsync(new Uri("https://example.com/"));
+
+            var result = sut.ShouldHaveMadeRequests(1);
 
             Assert.NotNull(result);
             Assert.IsType<HttpRequestMessageAsserter>(result);

--- a/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldHaveMadeRequestsTo.cs
+++ b/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldHaveMadeRequestsTo.cs
@@ -19,11 +19,29 @@ namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsT
         }
 
         [Fact]
+        public void ShouldHaveMadeRequestsToWithNumberOfRequests_NullHandler_ThrowsArgumentNullException()
+        {
+            TestableHttpMessageHandler sut = null;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.ShouldHaveMadeRequestsTo("https://example.com/", 1));
+            Assert.Equal("handler", exception.ParamName);
+        }
+
+        [Fact]
         public void ShouldHaveMadeRequestsTo_NullPattern_ThrowsArgumentNullException()
         {
             using var sut = new TestableHttpMessageHandler();
 
             var exception = Assert.Throws<ArgumentNullException>(() => sut.ShouldHaveMadeRequestsTo(null));
+            Assert.Equal("pattern", exception.ParamName);
+        }
+
+        [Fact]
+        public void ShouldHaveMadeRequestsToWithNumberOfRequests_NullPattern_ThrowsArgumentNullException()
+        {
+            using var sut = new TestableHttpMessageHandler();
+
+            var exception = Assert.Throws<ArgumentNullException>(() => sut.ShouldHaveMadeRequestsTo(null, 1));
             Assert.Equal("pattern", exception.ParamName);
         }
 #nullable restore
@@ -36,6 +54,26 @@ namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsT
             Assert.Throws<HttpRequestMessageAssertionException>(() => sut.ShouldHaveMadeRequestsTo("https://example.com/"));
         }
 
+
+        [Fact]
+        public void ShouldHaveMadeRequestsToWithNumberOfRequests_WhenNoRequestsWereMadeAndOneIsExpected_ThrowsHttpRequestMessageAssertionException()
+        {
+            using var sut = new TestableHttpMessageHandler();
+
+            Assert.Throws<HttpRequestMessageAssertionException>(() => sut.ShouldHaveMadeRequestsTo("https://example.com/", 1));
+        }
+
+        [Fact]
+        public void ShouldHaveMadeRequestsToWithNumberOfRequests_WhenNoRequestsWereMadeAndZeroRequestsAreExpected_ReturnsHttpRequestMessageAsserter()
+        {
+            using var sut = new TestableHttpMessageHandler();
+
+            var result = sut.ShouldHaveMadeRequestsTo("https://example.com/", 0);
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
         [Fact]
         public async Task ShouldHaveMadeRequestsTo_WhenMatchinRequestsWereMade_ReturnsHttpRequestMessageAsserter()
         {
@@ -45,6 +83,20 @@ namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsT
             _ = await client.GetAsync(new Uri("https://example.com/"));
 
             var result = sut.ShouldHaveMadeRequestsTo("https://example.com/");
+
+            Assert.NotNull(result);
+            Assert.IsType<HttpRequestMessageAsserter>(result);
+        }
+
+        [Fact]
+        public async Task ShouldHaveMadeRequestsToWithNumberOfRequests_WhenMatchinRequestsWereMade_ReturnsHttpRequestMessageAsserter()
+        {
+            using var sut = new TestableHttpMessageHandler();
+            using var client = new HttpClient(sut);
+
+            _ = await client.GetAsync(new Uri("https://example.com/"));
+
+            var result = sut.ShouldHaveMadeRequestsTo("https://example.com/", 1);
 
             Assert.NotNull(result);
             Assert.IsType<HttpRequestMessageAsserter>(result);

--- a/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldNotHaveMadeRequests.cs
+++ b/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldNotHaveMadeRequests.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsTests
 {
+    [Obsolete]
     public class ShouldNotHaveMadeRequests
     {
 #nullable disable

--- a/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldNotHaveMadeRequestsTo.cs
+++ b/test/TestableHttpClient.Tests/TestabeHttpMessageHandlerAssertionExtensionsTests/ShouldNotHaveMadeRequestsTo.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace TestableHttpClient.Tests.TestabeHttpMessageHandlerAssertionExtensionsTests
 {
+    [Obsolete]
     public class ShouldNotHaveMadeRequestsTo
     {
 #nullable disable


### PR DESCRIPTION
The methods `ShouldHaveMadeRequests`, `ShouldHaveMadeRequestsTo`, `HasMadeRequests` and `HasMadeRequestsTo` were missing the overload where the `expectedNumberOfRequests` could be set.
As a consequence, the methods `ShouldNotHaveMadeRequests` and `ShouldNotHaveMadeRequestsTo` are being deprecated because the same result can be achieved by passing `0` as the `expectedNumberOfRequests`

Fixes #69 .