### PR TITLE
Replace GitVersion with nbgv

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -13,6 +13,12 @@
       "commands": [
         "dotnet-sonarscanner"
       ]
+    },
+    "nbgv": {
+      "version": "3.3.37",
+      "commands": [
+        "nbgv"
+      ]
     }
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
       run: echo "$GITHUB_CONTEXT"
     - name: Checkout
       uses: actions/checkout@v2
-    - name: Fetch all history for all tags and branches
-      run: git fetch --prune --unshallow
+      with:
+        fetch-depth: 0
     - name: Update Java SDK for SonarQube
       uses: actions/setup-java@v1
       with:
@@ -33,7 +33,7 @@ jobs:
     - name: Restore dotnet tools
       run: dotnet tool restore
     - name: Prepare sonarqube
-      run: dotnet sonarscanner begin -d:sonar.host.url=https://sonarcloud.io -organization:dnperfors-github -key:dnperfors_TestableHttpClient -version:`dotnet gitversion -showvariable semver` -d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml -d:sonar.login=${{secrets.SONARCLOUD_TOKEN}}
+      run: dotnet sonarscanner begin -d:sonar.host.url=https://sonarcloud.io -organization:dnperfors-github -key:dnperfors_TestableHttpClient -version:`dotnet nbgv get-version --variable NuGetPackageVersion` -d:sonar.cs.opencover.reportsPaths=**/coverage.opencover.xml -d:sonar.login=${{secrets.SONARCLOUD_TOKEN}}
     - name: Restore dependencies
       run: dotnet restore
     - name: Build source code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to TestableHttpClient will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and 
 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [0.6] - unreleased
 ### Deprecated
 - `ShouldNotHaveMadeRequests(this TestableHttpMessageHandler)` will be removed in favour of the new `ShouldHaveMadeRequests(this HttpMessageHandler, 0)`.
 - `ShouldNotHaveMadeRequestsTo(this TestableHttpMessageHandler, string)` will be removed in favour of the new `ShouldHaveMadeRequestsTo(this HttpMessageHandler, string, 0)`.
@@ -28,6 +28,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `RespondWith(Action<HttpResponseMessageBuilder>)` sets `HttpResponseMessage.RequestMessage` by default before calling the builder action.
 
 - Build pipeline now uses .NET SDK by default including NETAnalyzers and C# 9
+- Build uses NerdBank.GitVersioning instead of GitVersion, since we have to specify the version number in the CHANGELOG.md anyways.
 
 ### Removed
 - `WithUriPattern(this IHttpRequestMessagesCheck, string)` was removed in favour of `WithRequestUri(this IHttpRequestMessagesCheck, string)`

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,3 +1,0 @@
-branches:
-    master:
-      tag: beta

--- a/version.json
+++ b/version.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "0.6-beta",
+  "versionHeightOffset": -1,
+  "publicReleaseRefSpec": [
+    "^refs/tags/v\\d+(?:\\.\\d+)?$"
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
This changes the version numbers of the nuget packages to include the git commit id, however this is deemed to be acceptable.